### PR TITLE
Add git reference docs and inline principles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -96,6 +96,16 @@ Patterns to watch for:
 
 Changes accumulate as dirty working tree state during a session. Do **not** commit automatically — wait for the user to confirm they are happy with each feature. Then group changes into meaningful, feature-scoped commits.
 
+**Five principles (the why behind the rules below):**
+
+1. **Atomic commits** — each commit has one reason to exist. If you can describe it with "and", split it. Atomic commits can be reverted independently, bisected to find regressions, and reviewed in isolation.
+2. **Messages tell the story** — explain *why*, not just *what*. The diff shows the what; the message is for context, motivation, and alternatives ruled out. Future contributors need the reasoning to make good decisions.
+3. **Revise before sharing** — your working history is a draft. Squash fixups, reorder for clarity, remove noise before pushing. The goal is a history someone else can read, not a truthful log of false starts.
+4. **Single-purpose branches** — keep branches focused. If development produced something independently useful, cherry-pick it out and land it early. Smaller PRs merge sooner, conflict less, and deliver value faster.
+5. **Linear history** — rebase feature branches onto main before merging. Group related commits under a descriptive merge commit. A readable history is a debugging tool.
+
+See `~/.claude/docs/git_practices.md` for the full reference — FutureLearn engineering post on commit hygiene and the branch triage runbook.
+
 **Before you commit — checklist:**
 > Re-read this before staging anything.
 - Has the user confirmed they're happy with the feature? Never commit automatically.
@@ -126,6 +136,18 @@ Changes accumulate as dirty working tree state during a session. Do **not** comm
 - Use a HEREDOC to pass the message to `git commit -m`
 
 **Branch cleanup before raising a PR and before merging:** review every commit with `git log main...<branch> --oneline`. Cleanup commits (renames, fixups, "oops" corrections) are noise — squash them into the commit they belong with. Every commit should tell one clear story. Do this twice: once before raising the PR, and again before merging in case review feedback triggered more fixup commits.
+
+**Squashing without interactive rebase** (interactive rebase is not available in Claude Code sessions — use this instead):
+
+```bash
+git checkout -b feature/<name>-clean origin/main
+git cherry-pick <sha>                          # individual commits to keep as-is
+git cherry-pick --no-commit <sha1> <sha2>      # group commits to squash into one
+git commit -m "..."
+git push origin feature/<name>-clean:feature/<name> --force
+git checkout feature/<name> && git reset --hard origin/feature/<name>
+git branch -D feature/<name>-clean
+```
 
 **Before you merge — checklist:**
 > Re-read this before running any merge command.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,7 +99,7 @@ Changes accumulate as dirty working tree state during a session. Do **not** comm
 **Five principles (the why behind the rules below):**
 
 1. **Atomic commits** — each commit has one reason to exist. If you can describe it with "and", split it. Atomic commits can be reverted independently, bisected to find regressions, and reviewed in isolation.
-2. **Messages tell the story** — explain *why*, not just *what*. The diff shows the what; the message is for context, motivation, and alternatives ruled out. Future contributors need the reasoning to make good decisions.
+2. **Messages tell the story** — the body must answer three questions: **Why** (what problem motivated this?), **Benefit unlocked** (what does this enable?), **Trade-offs** (why this approach over alternatives?). The diff shows the what; the message is for reasoning. A body that only describes what changed is incomplete.
 3. **Revise before sharing** — your working history is a draft. Squash fixups, reorder for clarity, remove noise before pushing. The goal is a history someone else can read, not a truthful log of false starts.
 4. **Single-purpose branches** — keep branches focused. If development produced something independently useful, cherry-pick it out and land it early. Smaller PRs merge sooner, conflict less, and deliver value faster.
 5. **Linear history** — rebase feature branches onto main before merging. Group related commits under a descriptive merge commit. A readable history is a debugging tool.
@@ -112,7 +112,7 @@ See `~/.claude/docs/git_practices.md` for the full reference — FutureLearn eng
 - Is this the smallest unit of change that delivers value on its own? (atomic — could it be reverted independently without breaking anything?)
 - Does each commit have exactly one reason to change? (Single Responsibility Principle — if you can describe it with "and", split it)
 - Is the first line a short imperative summary of the *value*, not the implementation? (< 72 chars)
-- Does the body explain *why* — the motivation, not just what changed?
+- Does the body answer all three: **Why** (motivation), **Benefit unlocked** (what this enables), **Trade-offs** (why this approach)?
 - Are unrelated changes in separate commits?
 - For multi-file commits, is there a `Changes:` list in the body?
 - Are relevant links/references included? (Claude session URLs, GitHub issues, external docs)

--- a/.claude/docs/git_practices.md
+++ b/.claude/docs/git_practices.md
@@ -1,0 +1,150 @@
+# Git practices
+
+Reference material underpinning the git conventions in `CLAUDE.md`. Two sections: the original FutureLearn engineering post on commit hygiene, and a branch triage runbook for cleaning up mixed-concern branches.
+
+---
+
+## Telling stories with your Git history
+
+*Published March 26th, 2015 by Seb Jacobs — FutureLearn engineering blog*
+
+Our Git history is a living, ever-changing, searchable record that tells the story of how and why our code is the way it is.
+
+### 1. Atomic commits
+
+Think of atomic commits as the smallest amount of code changed which delivers value. Apply the **Single Responsibility Principle** to commits — a commit should have exactly one reason to change. If you can describe a commit with "and", it's doing too much. Ask yourself: if this change needed to be reverted, would you want to undo all of it together, or just one part?
+
+### 2. Useful commit messages
+
+If there's one thing to remember, it is to explain why you've made the change in the first place. Look at the commit from the perspective of another developer. What questions might they be asking? What might not be immediately obvious?
+
+```
+Short one line title.
+
+An explanation of the problem, providing context.
+
+Longer description of what the change does.
+
+An explanation of why the change is being made.
+
+Perhaps a discussion of alternatives that were considered.
+```
+
+The first line should explain the *value* of the changes, not the implementation details.
+
+### 3. Revise history before sharing
+
+You shouldn't think of your Git history as a "truthful" log of what you worked on step-by-step. Just as we refactor code, we should refactor our commits before sharing them. Squash fixup commits, reorder for clarity, remove noise.
+
+### 4. Single purpose branches
+
+Think carefully about the purpose and scope of your feature branch. Changes that provide a clear benefit unrelated to the feature can be landed on main separately — and earlier. Splitting up branches reduces merge pain and delivers value sooner.
+
+### 5. Keep your history linear
+
+Rebase feature branches before merging. This groups related commits together while keeping merges clean, making it easier to identify when a particular change was introduced.
+
+---
+
+## Branch triage — cleaning up branches with mixed changes
+
+Long-running feature branches often accumulate changes that don't all belong together. Before raising PRs, triage what's there and separate the concerns.
+
+**The key driver is unblocking.** Fixes and docs that land on main become the shared base for all other branches. The merge order matters: low-risk, independent changes first — then larger features on top of a clean foundation.
+
+### When to do this
+
+- Multiple feature branches haven't been merged for a while
+- Some commits are clearly fixes or housekeeping with no dependency on the feature
+- A yak shave produced something independently useful that shouldn't wait for the feature
+- Other branches are blocked on changes buried inside a larger feature branch
+
+### Step 1 — survey the branches
+
+```bash
+for branch in feature/foo feature/bar; do
+  echo "=== $branch ==="
+  git log main...$branch --oneline
+done
+```
+
+Sort commits into buckets: **Fixes / correctness**, **Infrastructure / housekeeping**, **Research / documentation**, **New features**.
+
+### Step 2 — create focused branches from main
+
+```bash
+git checkout main
+git checkout -b feature/fixes
+git checkout -b feature/docs
+```
+
+### Step 3 — cherry-pick the right commits onto each branch
+
+```bash
+git checkout feature/fixes
+git cherry-pick <sha1> <sha2> <sha3>
+```
+
+Cherry-pick in chronological order. For session note conflicts (`SESSION.md`, `docs/session_log.md`), take `ours` — the current branch has the most recent note:
+
+```bash
+git cherry-pick -X ours <sha1> <sha2> <sha3>
+```
+
+### Step 4 — rebase the original feature branches onto the new base
+
+```bash
+git checkout feature/my-feature
+git rebase -X ours feature/fixes
+```
+
+Git automatically skips commits already upstream (recognised by patch content). `warning: skipped previously applied commit` is expected.
+
+### Step 5 — verify
+
+```bash
+for branch in feature/fixes feature/foo feature/bar; do
+  echo "=== $branch ==="
+  git log feature/fixes..$branch --oneline
+done
+```
+
+Each branch should show only the commits that genuinely belong to it.
+
+### Step 6 — raise PRs and force-push
+
+```bash
+git push -u origin feature/fixes
+gh pr create ...
+
+# After adding commits to an existing branch:
+git push --force-with-lease origin feature/fixes
+```
+
+Once `feature/fixes` merges to main, rebase all remaining branches:
+
+```bash
+git checkout feature/my-feature
+git rebase main
+git push --force-with-lease origin feature/my-feature
+```
+
+### Tips
+
+- **`-X ours` for session notes** — `SESSION.md` and `docs/session_log.md` conflict constantly. Taking `ours` is almost always correct.
+- **Empty commits** — if all changes were already in HEAD, use `git cherry-pick --skip`.
+- **Hollow branches** — after triage, some branches may only have session notes left. Delete once the focused branch merges.
+
+### Squashing without interactive rebase
+
+When interactive rebase isn't available, rebuild using `cherry-pick --no-commit`:
+
+```bash
+git checkout -b feature/<name>-clean origin/main
+git cherry-pick <sha>                          # individual commits
+git cherry-pick --no-commit <sha1> <sha2>      # squash group
+git commit -m "..."
+git push origin feature/<name>-clean:feature/<name> --force
+git checkout feature/<name> && git reset --hard origin/feature/<name>
+git branch -D feature/<name>-clean
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,11 @@ brew bundle         # Install/sync all packages from Brewfile
 **Managed locations:**
 - `./` — dotfiles (`.gitconfig`, `.zshrc`, `.editorconfig`, etc.) → symlinked to `$HOME`
 - `.oh-my-zsh/custom/` — shell environment, PATH, aliases, git shortcuts → sourced by Oh-My-Zsh at shell startup
-- `.claude/` — Claude Code settings, keybindings, global CLAUDE.md, skills, and agents → symlinked to `~/.claude/`
+- `.claude/` — Claude Code settings, keybindings, and global Claude config → symlinked to `~/.claude/`:
+  - `CLAUDE.md` — always loaded at session start; principles and rules, kept concise
+  - `skills/` — auto-discovered slash commands available in all projects
+  - `agents/` — named subagents invokable via the Agent tool
+  - `docs/` — longer reference material (not auto-loaded; CLAUDE.md points to these by path)
 - `bin/` — shell utilities → symlinked into `~/bin/`
 - `Brewfile` — full tool inventory (Homebrew formulae, casks, Go/Rust/Python/NPM packages)
 

--- a/setup.sh
+++ b/setup.sh
@@ -51,6 +51,7 @@ files=(
   ".claude/keybindings.json"
   ".claude/skills"
   ".claude/agents"
+  ".claude/docs"
 )
 
 for file in "${files[@]}"


### PR DESCRIPTION
## Summary

The git section of global CLAUDE.md had detailed checklists but no rationale — agents could recite the rules but couldn't explain the reasoning behind them, and had no runbook for messier situations like mixed-concern branches. The content also only existed in a single project repo, not available everywhere.

This PR adds a `.claude/docs/` folder as the home for longer reference material that CLAUDE.md points to but doesn't inline, and populates it with the git practices doc. Five principles are inlined directly into CLAUDE.md so the "why" is always active, not just when the doc is explicitly read.

A/B tested before merging: agents with the new docs scored 21/24 vs 19/24 for CLAUDE.md-only on commit conventions and branch cleanup questions. The margin is modest — CLAUDE.md already had the rules — but the docs add the bucket taxonomy and worked-example depth that turn abstract rules into followable procedures.

## Key changes

- `setup.sh` — adds `.claude/docs` to the symlink list alongside skills and agents
- `.claude/docs/git_practices.md` — FutureLearn commit hygiene post (5 principles) and branch triage runbook; generic steps only, project-specific worked examples stay in individual repos
- `.claude/CLAUDE.md` — five git principles inlined at the top of the git section (the "why" behind the checklists), squashing snippet for Claude Code sessions where `git rebase -i` isn't available, pointer to the docs file
- `CLAUDE.md` (root) — `.claude/` architecture note expanded to distinguish the four subdirectories and their loading behaviour

## Gotchas

- `docs/` is on-demand, not auto-loaded — CLAUDE.md points to it by path and agents read it when the topic is relevant. Skills are auto-discovered; docs are not.
- The inlined principles are intentionally brief — the docs file has the full rationale and examples. Two layers: always-visible rules, on-demand depth.

## References

- A/B eval: two parallel subagents (with/without docs) scored by Opus on completeness, accuracy, actionability, gaps — results in session notes

## Test plan

- [ ] `setup.sh` creates `~/.claude/docs → ~/dotfiles/.claude/docs` correctly
- [ ] Agent asked about commit conventions answers with why/benefit/trade-offs framing, not just rule-listing
- [ ] Agent asked about branch triage uses the bucket taxonomy and runbook steps from the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)