### PR TITLE
Add /save and /recover skills; consolidate SESSION.md conventions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,6 +25,7 @@ SESSION.md is scoped to the current feature branch. It exists for continuity acr
 - **Create it** at the start of a feature branch with the goal, approach, and any key decisions made upfront
 - **Update it often** — after each meaningful chunk of work, not just at the end of a session; include what was done, what was decided, and what's next
 - **Always end with a handover prompt** — a blockquote that summarises what was just done, names the next task, the approach, and what "done" looks like; a fresh Claude session should be able to read it cold and pick up exactly where this one left off
+- **Heading formats:** session notes use `## YYYY-MM-DD HH:MM | branch-name`; mid-session checkpoints use `### Checkpoint — HH:MM` nested under the session note
 - **Commit it separately** from code changes — this makes it easy to drop or squash SESSION.md commits when cleaning up history before a merge
 - **Archive before merging** — append to `docs/session_log.md`, then reset SESSION.md to a single "next up" line so the next branch starts fresh
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,12 +17,22 @@ Before merging a change to CLAUDE.md, `~/.claude/docs/`, or a project skill, run
 
 See `~/.claude/docs/eval_config_changes.md` for the full rubric, agent prompt templates, and a worked example.
 
+## SESSION.md
+
+SESSION.md is scoped to the current feature branch. It exists for continuity across multiple pairing sessions and to survive session crashes — so that anyone (including Claude) picking up mid-flow can read it and know exactly where things stand.
+
+- **Read it first** — even when not running `/start`. It's the primary handoff document and contains context that CLAUDE.md and TODO.md won't have.
+- **Create it** at the start of a feature branch with the goal, approach, and any key decisions made upfront
+- **Update it often** — after each meaningful chunk of work, not just at the end of a session; include what was done, what was decided, and what's next
+- **Always end with a handover prompt** — a blockquote that summarises what was just done, names the next task, the approach, and what "done" looks like; a fresh Claude session should be able to read it cold and pick up exactly where this one left off
+- **Commit it separately** from code changes — this makes it easy to drop or squash SESSION.md commits when cleaning up history before a merge
+- **Archive before merging** — append to `docs/session_log.md`, then reset SESSION.md to a single "next up" line so the next branch starts fresh
+
 ## Session start routine
 
 Run `/start` at the beginning of every session — the `start-session` skill has the full steps.
 
 Principles:
-- **Read `SESSION.md` first** if it exists in the project root — even when not running `/start`. It's the primary handoff document and contains context that CLAUDE.md and TODO.md won't have.
 - Ask about available time and hard stops before reading anything
 - Ask if the session should use ping-pong TDD mode — invoke `/pingpong` if yes
 - Propose **one concrete goal** — not a wish list
@@ -34,7 +44,6 @@ Principles:
 Run `/finish` at the end of every session — the `finish-session` skill has the full steps. Also handles mid-session breaks (`/break`) in quick mode.
 
 Principles:
-- SESSION.md is the primary handoff — always leave a handover prompt for the next session
 - Check the project's CLAUDE.md for any additional session-end requirements
 
 ## Working hours
@@ -43,11 +52,11 @@ Cut-off is 7PM. If a session is running past 7PM, say so directly — don't let 
 
 ## Managing context
 
-**Use `/clear` liberally.** Context is the scarcest resource in a session — clearing it when a thread is done keeps later work sharp. SESSION.md exists precisely to make `/clear` cheap: one read at the start of the next thread gets you back up to speed.
+**Use `/clear` liberally.** Context is the scarcest resource in a session — clearing it when a thread is done keeps later work sharp. SESSION.md makes `/clear` cheap: one read at the start of the next thread gets you back up to speed.
 
 Within a session, the main levers for keeping context lean:
 
-- **`/clear`** — reset when a thread concludes or goes stale; SESSION.md is the handoff
+- **`/clear`** — reset when a thread concludes or goes stale
 - **Subagents for exploratory work** — browsing, reading many files, running scripts; the subagent absorbs the cost and returns a summary, leaving the main context clean
 - **Background Bash for parallel compute** — chunked processing, batch jobs; simpler than subagents, inherits approved permissions
 

--- a/.claude/skills/finish-session/SKILL.md
+++ b/.claude/skills/finish-session/SKILL.md
@@ -16,7 +16,7 @@ Runs the end-of-session checklist from CLAUDE.md. Ensures every session ends cle
 ### 0 — Get the current time
 
 Run `date` to get the actual current time before doing anything else. Use this to:
-- Label the session note accurately (morning / afternoon / evening suffix if multiple notes on the same day)
+- Label the session note with the canonical heading format: `## YYYY-MM-DD HH:MM | branch-name`
 - Check whether the session is running past 7PM — if so, flag it
 - Confirm the correct date for all file edits
 
@@ -24,7 +24,7 @@ Run `date` to get the actual current time before doing anything else. Use this t
 
 ### 1 — Update the session note
 
-At the top of `SESSION.md`, update (or create) the `## Session note — YYYY-MM-DD` block for today:
+At the top of `SESSION.md`, update (or create) the `## YYYY-MM-DD HH:MM | branch-name` block for today:
 
 - What was built or fixed
 - Key decisions made and the reasoning

--- a/.claude/skills/recover-session/SKILL.md
+++ b/.claude/skills/recover-session/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: recover-session
+description: Recover context from a crashed or unfinished session by reading the most recent JSONL transcript. Use when the user says "/recover", "recover session", "what was I doing", or when /start detects that SESSION.md is stale relative to the last session transcript.
+---
+
+# Recover Session
+
+Retrospective summary from Claude Code's JSONL session transcript. Use after a crash, unexpected exit, or any session that ended without running `/finish` — reconstructs what happened and writes it into SESSION.md so the next session can pick up cleanly.
+
+---
+
+## Steps
+
+### 0 — Identify the project hash
+
+The current project's sessions are stored under `~/.claude/projects/`. The directory name is the absolute path with `/` replaced by `-` and leading `-`. For the current working directory, construct the path:
+
+```bash
+# Derive the project hash from cwd
+PROJECT_DIR="$HOME/.claude/projects/$(pwd | sed 's|/|-|g')"
+echo "$PROJECT_DIR"
+ls -lt "$PROJECT_DIR"/*.jsonl | head -5
+```
+
+This lists the most recent JSONL files by modification time. The most recent one is likely the crashed session.
+
+---
+
+### 1 — Confirm the right session
+
+Show the user the timestamp and first user message from the most recent JSONL file so they can confirm it's the right session to recover:
+
+```bash
+LATEST=$(ls -t "$PROJECT_DIR"/*.jsonl | head -1)
+# Show file modification time
+stat -f "%Sm" "$LATEST"
+# Show first user message
+python3 -c "
+import json, sys
+for line in open('$LATEST'):
+    msg = json.loads(line)
+    if msg.get('type') == 'user':
+        content = msg.get('message', {}).get('content', '')
+        if isinstance(content, str):
+            print(content[:200])
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get('type') == 'text':
+                    print(block['text'][:200])
+                    break
+        break
+"
+```
+
+Ask the user: "Is this the session to recover from, or should I look at an older one?"
+
+Wait for confirmation before proceeding.
+
+---
+
+### 2 — Extract the conversation
+
+Filter the JSONL to only human and assistant text turns — skip `tool_use`, `tool_result`, `file-history-snapshot`, `permission-mode`, and `attachment` entries. This dramatically reduces noise.
+
+```bash
+python3 -c "
+import json, sys
+
+for line in open('$LATEST'):
+    msg = json.loads(line)
+    msg_type = msg.get('type')
+
+    if msg_type == 'user':
+        content = msg.get('message', {}).get('content', '')
+        if isinstance(content, str) and content.strip():
+            print(f'## User\n{content[:500]}\n')
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get('type') == 'text':
+                    print(f'## User\n{block[\"text\"][:500]}\n')
+                    break
+
+    elif msg_type == 'assistant':
+        content = msg.get('message', {}).get('content', '')
+        if isinstance(content, str) and content.strip():
+            print(f'## Assistant\n{content[:500]}\n')
+        elif isinstance(content, list):
+            texts = [b.get('text','') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+            combined = ' '.join(texts).strip()
+            if combined:
+                print(f'## Assistant\n{combined[:500]}\n')
+" > /tmp/recovered-session.md
+wc -l /tmp/recovered-session.md
+```
+
+Read the extracted conversation to understand what happened.
+
+---
+
+### 3 — Synthesise into SESSION.md format
+
+From the extracted conversation, write a session note covering:
+
+- **What was built or fixed** — concrete outcomes, not process
+- **Key decisions made** — with reasoning where recoverable
+- **Where things stopped** — what was in progress when the session ended
+- **Decisions for next session** — priorities inferred from the trajectory
+- **Handover prompt** — a self-contained paragraph the next session can read cold
+
+This follows the same format as `/finish` step 1, but reconstructed rather than live.
+
+---
+
+### 4 — Archive the old SESSION.md and write the recovery
+
+If `SESSION.md` already exists and has content:
+
+1. Check whether the existing content is stale (predates the recovered session). If so, it's from an even earlier session — preserve it by appending to `docs/session_log.md` before overwriting.
+2. If the existing content is from the same date, merge the recovery into it rather than replacing.
+
+Write the recovered session note to `SESSION.md`.
+
+---
+
+### 5 — Report
+
+Summarise what was recovered:
+
+> "Recovered session from [date/time]. Key context: [1-2 sentence summary]. Written to SESSION.md — ready to continue with `/start` or pick up directly."
+
+Flag anything that couldn't be recovered (e.g. if the session was very short or mostly tool output with little conversation).

--- a/.claude/skills/save-session/SKILL.md
+++ b/.claude/skills/save-session/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: save-session
+description: Mid-session checkpoint — snapshot current decisions and progress into SESSION.md without archiving or cleaning up. Use when the user says "/save", "checkpoint", "save progress", or before risky operations like schema migrations, large refactors, or long-running tasks.
+---
+
+# Save Session
+
+Mid-session checkpoint. Captures current progress and decisions in SESSION.md without the full end-of-session routine. Does **not** archive, move roadmap items, or propose commits.
+
+Use before risky operations (migrations, large refactors, Playwright runs) or when you want to preserve state before a `/clear`.
+
+---
+
+## Steps
+
+### 0 — Get the current time
+
+Run `date` to timestamp the checkpoint accurately.
+
+---
+
+### 1 — Read current SESSION.md
+
+Read `SESSION.md` to understand the existing session note structure. If there's already a session note for today, you'll be appending to it — not replacing it.
+
+---
+
+### 2 — Write the checkpoint
+
+In `SESSION.md`, update the current session note block (`## Session note — YYYY-MM-DD`) with a `### Checkpoint — HH:MM` sub-heading. Under it, write:
+
+- **Progress so far** — what's been built, fixed, or changed since the session started (or since the last checkpoint)
+- **Decisions made** — any choices settled during this segment, with brief reasoning
+- **Current state** — where things stand right now: what's working, what's half-done, any dirty git state worth noting
+- **Next steps** — what you're about to do next (useful context if the session crashes or `/clear` is run)
+
+Keep it concise — this is a snapshot, not a session summary. A few bullet points per section is enough.
+
+If there's already a checkpoint from earlier in the session, leave it in place and add the new one below it. Checkpoints are append-only within a session.
+
+---
+
+### 3 — Confirm
+
+Report back briefly:
+
+> "Checkpoint saved in SESSION.md at HH:MM. Safe to `/clear` or continue."
+
+Do **not** propose commits, update the roadmap, or archive anything. That's `/finish`'s job.

--- a/.claude/skills/save-session/SKILL.md
+++ b/.claude/skills/save-session/SKILL.md
@@ -27,7 +27,7 @@ Read `SESSION.md` to understand the existing session note structure. If there's 
 
 ### 2 — Write the checkpoint
 
-In `SESSION.md`, update the current session note block (`## Session note — YYYY-MM-DD`) with a `### Checkpoint — HH:MM` sub-heading. Under it, write:
+In `SESSION.md`, update the current session note block (`## YYYY-MM-DD HH:MM | branch-name`) with a `### Checkpoint — HH:MM` sub-heading. Under it, write:
 
 - **Progress so far** — what's been built, fixed, or changed since the session started (or since the last checkpoint)
 - **Decisions made** — any choices settled during this segment, with brief reasoning

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -11,12 +11,32 @@ Runs the session start routine documented in CLAUDE.md. Ensures every session be
 
 ## Steps
 
-### 0 — Get the current time
+### 0 — Get the current time and check for stale sessions
 
 Run `date` to get the actual current time before doing anything else. Use this to:
 - Confirm the correct date for session note labelling
 - Accurately compute cron expressions for hard stop warnings and break reminders
 - Check whether the session start is already past 7PM
+
+Then check whether the previous session ended cleanly by comparing `SESSION.md` mtime against the most recent JSONL transcript:
+
+```bash
+PROJECT_DIR="$HOME/.claude/projects/$(pwd | sed 's|/|-|g')"
+LATEST_JSONL=$(ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1)
+if [ -n "$LATEST_JSONL" ] && [ -f "SESSION.md" ]; then
+  JSONL_MTIME=$(stat -f "%m" "$LATEST_JSONL")
+  SESSION_MTIME=$(stat -f "%m" "SESSION.md")
+  if [ "$JSONL_MTIME" -gt "$SESSION_MTIME" ]; then
+    echo "⚠️  SESSION.md is older than the last session transcript — previous session may not have run /finish"
+  fi
+fi
+```
+
+If the check fires, tell the user:
+
+> "It looks like the last session didn't run `/finish` — SESSION.md is older than the most recent transcript. Want me to run `/recover` to reconstruct what happened, or skip and continue from the current SESSION.md?"
+
+Wait for their answer. If they say recover, invoke `/recover` before continuing with step 1.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two new session skills (`/save`, `/recover`) and consolidates SESSION.md conventions into a dedicated CLAUDE.md section with standardised heading formats.

## Key changes

- `.claude/skills/save-session/SKILL.md` — new `/save` skill for mid-session checkpoints without the full end-of-session routine
- `.claude/skills/recover-session/SKILL.md` — new `/recover` skill to reconstruct context from JSONL transcripts after a crash or missed `/finish`
- `.claude/skills/start-session/SKILL.md` — stale session detection: compares SESSION.md mtime vs latest JSONL and offers to run `/recover` if stale
- `.claude/CLAUDE.md` — SESSION.md conventions extracted into their own section; heading format standardised to `## YYYY-MM-DD HH:MM | branch-name`
- `.claude/skills/finish-session/SKILL.md` — updated to use canonical heading format