### PR TITLE
Replace SESSION.md with session-logger CLI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,17 +17,16 @@ Before merging a change to CLAUDE.md, `~/.claude/docs/`, or a project skill, run
 
 See `~/.claude/docs/eval_config_changes.md` for the full rubric, agent prompt templates, and a worked example.
 
-## SESSION.md
+## Session logging
 
-SESSION.md is scoped to the current feature branch. It exists for continuity across multiple pairing sessions and to survive session crashes — so that anyone (including Claude) picking up mid-flow can read it and know exactly where things stand.
+Session notes are stored in a private data repo via `session_logger.py`, not in project repos. This eliminates the merge-time cleanup ceremony that SESSION.md required (prefix commits, manual resets, archiving).
 
-- **Read it first** — even when not running `/start`. It's the primary handoff document and contains context that CLAUDE.md and TODO.md won't have.
-- **Create it** at the start of a feature branch with the goal, approach, and any key decisions made upfront
-- **Update it often** — after each meaningful chunk of work, not just at the end of a session; include what was done, what was decided, and what's next
-- **Always end with a handover prompt** — a blockquote that summarises what was just done, names the next task, the approach, and what "done" looks like; a fresh Claude session should be able to read it cold and pick up exactly where this one left off
-- **Heading formats:** session notes use `## YYYY-MM-DD HH:MM | branch-name`; mid-session checkpoints use `### Checkpoint — HH:MM` nested under the session note
-- **Commit it separately** from code changes — this makes it easy to drop or squash SESSION.md commits when cleaning up history before a merge
-- **Archive before merging** — append to `docs/session_log.md`, then reset SESSION.md to a single "next up" line so the next branch starts fresh
+- **Storage:** JSONL entries at `$SESSION_LOGS_DATA/logs/<project>/<branch>.jsonl`, one JSON object per line
+- **Branch names:** `/` replaced with `+` in filenames (e.g. `feature+auth.jsonl`)
+- **Commands:** `write` (append entry), `tail` (read recent), `ls` (list projects/branches), `search` (content search)
+- **Git integration:** every `write` auto-commits in the data repo; `--type finish` also pushes to remote
+- **Skills handle it:** `/start`, `/save`, `/finish`, `/break` call `session_logger.py` — no manual session note management needed
+- **Context restoration:** `/start` runs `tail --limit 5` to restore context from the last few entries; the most recent finish entry's `**Next:**` field is the handover prompt
 
 ## Session start routine
 
@@ -53,7 +52,7 @@ Cut-off is 7PM. If a session is running past 7PM, say so directly — don't let 
 
 ## Managing context
 
-**Use `/clear` liberally.** Context is the scarcest resource in a session — clearing it when a thread is done keeps later work sharp. SESSION.md makes `/clear` cheap: one read at the start of the next thread gets you back up to speed.
+**Use `/clear` liberally.** Context is the scarcest resource in a session — clearing it when a thread is done keeps later work sharp. Session logs make `/clear` cheap: `/start` restores context from the data repo automatically.
 
 Within a session, the main levers for keeping context lean:
 

--- a/.claude/skills/break-session/SKILL.md
+++ b/.claude/skills/break-session/SKILL.md
@@ -5,6 +5,49 @@ description: Save mid-session state before a break. Use when the user says "/bre
 
 # Break Session
 
-Run `finish-session` in quick mode: steps 0, 1 (progress note only — no handover prompt), and 8 (commit anything worth saving). Skip steps 2–7.
+Quick checkpoint before stepping away. Captures current state, commits any dirty work, cancels the session timer.
 
-Also cancel the session cron timer if one is running (`CronDelete <job-id>`) — `/start` will set a fresh one on return.
+---
+
+## Steps
+
+### 0 — Get context
+
+Run `date` to get the current time.
+
+Determine the project name and branch:
+
+```bash
+basename "$(git rev-parse --show-toplevel)"
+git rev-parse --abbrev-ref HEAD
+```
+
+### 1 — Write the break entry
+
+Summarise current progress in a few bullet points, then write it:
+
+```bash
+session_logger.py write \
+  --project <project> \
+  --branch <branch> \
+  --type break \
+  --content "<what's been done, current state, anything half-finished>" \
+  --next "<what to pick up on return>"
+```
+
+### 2 — Commit dirty work
+
+```bash
+git status
+git diff --stat
+```
+
+If there are uncommitted changes worth saving, propose a grouping to the user and commit after approval. Don't leave half-done work uncommitted across a break.
+
+### 3 — Cancel session timer
+
+If a session cron timer is running, cancel it with `CronDelete <job-id>`. `/start` will set a fresh one on return.
+
+### 4 — Confirm
+
+> "Break saved. Run `/start` when you're back."

--- a/.claude/skills/finish-session/SKILL.md
+++ b/.claude/skills/finish-session/SKILL.md
@@ -1,40 +1,45 @@
 ---
 name: finish-session
-description: Run the end-of-session checklist — update session note in SESSION.md, move completed items to DONE.md, add new items to ROADMAP.md or BACKLOG.md, check CLAUDE.md is current, review dirty git state and propose commits. Also handles mid-session breaks (/break) in quick mode: steps 0, 1, and 8 only. Use when the user says "/finish", "/finish-session", "/end", "let's wrap up", "wrap up", "let's finish", "end this session", "let's call it", "that's enough for today", "/break", "taking a break", "back in a bit", or similar.
+description: Run the end-of-session checklist — write session summary to session log, move completed items to DONE.md, add new items to ROADMAP.md, check CLAUDE.md is current, review dirty git state and propose commits. Use when the user says "/finish", "/finish-session", "/end", "let's wrap up", "wrap up", "let's finish", "end this session", "let's call it", "that's enough for today", or similar.
 ---
 
 # Finish Session
 
-Runs the end-of-session checklist from CLAUDE.md. Ensures every session ends cleanly with the handoff state captured for next time.
+Runs the end-of-session checklist. Ensures every session ends cleanly with the handoff state captured for next time.
 
-**Mid-session break (`/break`)?** Run steps 0, 1 (progress note only — no handover prompt needed), and 8 (commit anything worth saving). Skip everything else. Cancel the session cron timer if one is running (`CronDelete <job-id>`) — `/start` will set a fresh one on return.
+**Mid-session break (`/break`)?** Use the `break-session` skill instead.
 
 ---
 
 ## Steps
 
-### 0 — Get the current time
+### 0 — Get context
 
-Run `date` to get the actual current time before doing anything else. Use this to:
-- Label the session note with the canonical heading format: `## YYYY-MM-DD HH:MM | branch-name`
-- Check whether the session is running past 7PM — if so, flag it
-- Confirm the correct date for all file edits
+Run `date` to get the actual current time. Check whether the session is running past 7PM — if so, flag it.
+
+Determine the project name and branch:
+
+```bash
+basename "$(git rev-parse --show-toplevel)"
+git rev-parse --abbrev-ref HEAD
+```
 
 ---
 
-### 1 — Update the session note
+### 1 — Write the finish entry
 
-At the top of `SESSION.md`, update (or create) the `## YYYY-MM-DD HH:MM | branch-name` block for today:
+Summarise the session — what was built or fixed, key decisions, anything discovered that changed the plan. The `--next` field is the handover: the 2-3 most important things to pick up next session, in priority order.
 
-- What was built or fixed
-- Key decisions made and the reasoning
-- Anything discovered that changed the plan
-- **Decisions for next session** — the 2–3 most important things to pick up, in priority order
-- **Handover prompt** — a self-contained paragraph (or short block) the next Claude session can read cold and immediately understand what was just done and what to pick up next. Written in second person ("PR #X merged. X replaces Y…"). Include: what shipped, any gotchas/debt left behind, and the next priorities in order. Put this in a `> blockquote` after the session note body, labelled `**Handover prompt for next session:**`. This is the single most important thing to get right — it's what turns a session note into a live handoff.
+```bash
+session_logger.py write \
+  --project <project> \
+  --branch <branch> \
+  --type finish \
+  --content "<session summary: what shipped, decisions made, gotchas/debt>" \
+  --next "<top priorities for next session, in order>"
+```
 
-Keep it factual and concise. This is the primary handoff mechanism — the next session starts by reading it.
-
-Do **not** write to `docs/session_log.md` during `/finish`. Session notes are archived to session_log.md at PR merge time (see step 6).
+This auto-commits and pushes to the data repo remote.
 
 ---
 
@@ -50,7 +55,6 @@ Anything discovered during the session that needs doing:
 - New task for the active sprint → add to `ROADMAP.md` **Now**
 - Agreed next priority → add to `ROADMAP.md` **Next**
 - Backlog idea / later item → add to `ROADMAP.md` **Later** (or `BACKLOG.md` if detailed)
-- Session note bullet → add to `SESSION.md` current session note
 
 Don't leave it to memory.
 
@@ -67,23 +71,11 @@ In `ROADMAP.md`:
 
 ### 5 — Update CLAUDE.md
 
-If anything changed — new script, renamed column, updated workflow, new skill, schema change — update the relevant section of `CLAUDE.md` in this session. Future sessions start by reading it; stale docs are worse than no docs.
+If anything changed — new script, renamed column, updated workflow, new skill, schema change — update the relevant section of the project's `CLAUDE.md`. Future sessions start by reading it; stale docs are worse than no docs.
 
 ---
 
-### 6 — Archive to session_log.md (if merging now)
-
-If this `/finish` is happening immediately before merging a PR to main, append the session notes to `docs/session_log.md` and reset SESSION.md:
-
-1. Append the current SESSION.md notes to the bottom of `docs/session_log.md`. Heading format: `## YYYY-MM-DD HH:MM | branch-name` (short timestamp — date + time, no seconds).
-2. Run `git checkout main -- SESSION.md` to reset SESSION.md to the main branch version.
-3. Commit both files together: `"Archive session notes: branch-name"`.
-
-Skip this step if the PR is not being merged this session — the notes stay in SESSION.md on the branch until merge.
-
----
-
-### 7 — Update open PR TODO checklists
+### 6 — Update open PR TODO checklists
 
 Check for any open PRs on the current branch or any feature branches worked on this session:
 
@@ -95,7 +87,7 @@ For each open PR, review what's left to do and add any remaining TODOs as a chec
 
 ---
 
-### 8 — Check dirty state and propose commits
+### 7 — Check dirty state and propose commits
 
 ```bash
 git status
@@ -104,14 +96,9 @@ git diff --stat
 
 Survey all uncommitted changes. Propose a grouping to the user — one commit per logical feature or change. Wait for approval before staging or committing.
 
-Commit message format:
-- First line: short imperative summary (< 72 chars)
-- Body: why the change was made, not just what
-- End with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
-
 ---
 
-### 9 — Final check
+### 8 — Final check
 
 Once commits are done:
 
@@ -122,6 +109,8 @@ git status
 Tree should be clean. If not, flag any remaining uncommitted files and ask whether to commit, stash, or leave.
 
 Confirm push if not already done.
+
+Cancel the session cron timer if one is running (`CronDelete <job-id>`).
 
 ---
 

--- a/.claude/skills/recover-session/SKILL.md
+++ b/.claude/skills/recover-session/SKILL.md
@@ -1,40 +1,49 @@
 ---
 name: recover-session
-description: Recover context from a crashed or unfinished session by reading the most recent JSONL transcript. Use when the user says "/recover", "recover session", "what was I doing", or when /start detects that SESSION.md is stale relative to the last session transcript.
+description: Recover context from a crashed or unfinished session by reading the most recent JSONL transcript. Use when the user says "/recover", "recover session", "what was I doing", or when /start detects the last entry isn't a finish.
 ---
 
 # Recover Session
 
-Retrospective summary from Claude Code's JSONL session transcript. Use after a crash, unexpected exit, or any session that ended without running `/finish` — reconstructs what happened and writes it into SESSION.md so the next session can pick up cleanly.
+Retrospective summary from Claude Code's JSONL session transcript. Use after a crash, unexpected exit, or any session that ended without running `/finish` — reconstructs what happened and writes a recovery entry to the session log so the next session can pick up cleanly.
 
 ---
 
 ## Steps
 
-### 0 — Identify the project hash
+### 0 — Detect the situation
 
-The current project's sessions are stored under `~/.claude/projects/`. The directory name is the absolute path with `/` replaced by `-` and leading `-`. For the current working directory, construct the path:
+Determine the project name and branch:
 
 ```bash
-# Derive the project hash from cwd
-PROJECT_DIR="$HOME/.claude/projects/$(pwd | sed 's|/|-|g')"
-echo "$PROJECT_DIR"
-ls -lt "$PROJECT_DIR"/*.jsonl | head -5
+basename "$(git rev-parse --show-toplevel)"
+git rev-parse --abbrev-ref HEAD
 ```
 
-This lists the most recent JSONL files by modification time. The most recent one is likely the crashed session.
+Check the last session log entry:
+
+```bash
+session_logger.py tail --project <project> --branch <branch> --limit 1
+```
+
+If the last entry is a `finish`, the session ended cleanly — nothing to recover. Tell the user and stop.
+
+If the last entry is `start`, `checkpoint`, or `break` (or there are no entries), the previous session likely crashed or the user forgot `/finish`.
 
 ---
 
-### 1 — Confirm the right session
+### 1 — Find the transcript
 
-Show the user the timestamp and first user message from the most recent JSONL file so they can confirm it's the right session to recover:
+```bash
+PROJECT_DIR="$HOME/.claude/projects/$(pwd | sed 's|/|-|g')"
+ls -lt "$PROJECT_DIR"/*.jsonl | head -5
+```
+
+Show the user the timestamp and first user message from the most recent transcript so they can confirm it's the right session:
 
 ```bash
 LATEST=$(ls -t "$PROJECT_DIR"/*.jsonl | head -1)
-# Show file modification time
 stat -f "%Sm" "$LATEST"
-# Show first user message
 python3 -c "
 import json, sys
 for line in open('$LATEST'):
@@ -60,7 +69,7 @@ Wait for confirmation before proceeding.
 
 ### 2 — Extract the conversation
 
-Filter the JSONL to only human and assistant text turns — skip `tool_use`, `tool_result`, `file-history-snapshot`, `permission-mode`, and `attachment` entries. This dramatically reduces noise.
+Filter the JSONL to only human and assistant text turns — skip `tool_use`, `tool_result`, `file-history-snapshot`, `permission-mode`, and `attachment` entries:
 
 ```bash
 python3 -c "
@@ -97,35 +106,25 @@ Read the extracted conversation to understand what happened.
 
 ---
 
-### 3 — Synthesise into SESSION.md format
+### 3 — Write the recovery entry
 
-From the extracted conversation, write a session note covering:
+From the extracted conversation, synthesise a recovery entry:
 
-- **What was built or fixed** — concrete outcomes, not process
-- **Key decisions made** — with reasoning where recoverable
-- **Where things stopped** — what was in progress when the session ended
-- **Decisions for next session** — priorities inferred from the trajectory
-- **Handover prompt** — a self-contained paragraph the next session can read cold
+```bash
+session_logger.py write \
+  --project <project> \
+  --branch <branch> \
+  --type finish \
+  --content "<what was built/fixed, key decisions, where things stopped>" \
+  --next "<priorities inferred from the session trajectory>"
+```
 
-This follows the same format as `/finish` step 1, but reconstructed rather than live.
-
----
-
-### 4 — Archive the old SESSION.md and write the recovery
-
-If `SESSION.md` already exists and has content:
-
-1. Check whether the existing content is stale (predates the recovered session). If so, it's from an even earlier session — preserve it by appending to `docs/session_log.md` before overwriting.
-2. If the existing content is from the same date, merge the recovery into it rather than replacing.
-
-Write the recovered session note to `SESSION.md`.
+Use `--type finish` so the log correctly marks the session as closed.
 
 ---
 
-### 5 — Report
+### 4 — Report
 
-Summarise what was recovered:
+> "Recovered session from [date/time]. Key context: [1-2 sentence summary]. Ready to continue with `/start`."
 
-> "Recovered session from [date/time]. Key context: [1-2 sentence summary]. Written to SESSION.md — ready to continue with `/start` or pick up directly."
-
-Flag anything that couldn't be recovered (e.g. if the session was very short or mostly tool output with little conversation).
+Flag anything that couldn't be recovered (very short session, mostly tool output with little conversation).

--- a/.claude/skills/save-session/SKILL.md
+++ b/.claude/skills/save-session/SKILL.md
@@ -1,49 +1,52 @@
 ---
 name: save-session
-description: Mid-session checkpoint — snapshot current decisions and progress into SESSION.md without archiving or cleaning up. Use when the user says "/save", "checkpoint", "save progress", or before risky operations like schema migrations, large refactors, or long-running tasks.
+description: Mid-session checkpoint — snapshot current decisions and progress without archiving or cleaning up. Use when the user says "/save", "checkpoint", "save progress", or before risky operations like schema migrations, large refactors, or long-running tasks.
 ---
 
 # Save Session
 
-Mid-session checkpoint. Captures current progress and decisions in SESSION.md without the full end-of-session routine. Does **not** archive, move roadmap items, or propose commits.
+Mid-session checkpoint. Captures current progress and decisions without the full end-of-session routine. Does **not** archive, move roadmap items, or propose commits.
 
-Use before risky operations (migrations, large refactors, Playwright runs) or when you want to preserve state before a `/clear`.
+Use before risky operations (migrations, large refactors) or when you want to preserve state before a `/clear`.
 
 ---
 
 ## Steps
 
-### 0 — Get the current time
+### 0 — Get context
 
-Run `date` to timestamp the checkpoint accurately.
+Run `date` to get the current time.
 
----
+Determine the project name and branch:
 
-### 1 — Read current SESSION.md
+```bash
+basename "$(git rev-parse --show-toplevel)"
+git rev-parse --abbrev-ref HEAD
+```
 
-Read `SESSION.md` to understand the existing session note structure. If there's already a session note for today, you'll be appending to it — not replacing it.
+### 1 — Read recent context
 
----
+```bash
+session_logger.py tail --project <project> --branch <branch> --limit 3
+```
+
+Review the last few entries to understand what's already been captured — avoid duplicating.
 
 ### 2 — Write the checkpoint
 
-In `SESSION.md`, update the current session note block (`## YYYY-MM-DD HH:MM | branch-name`) with a `### Checkpoint — HH:MM` sub-heading. Under it, write:
+```bash
+session_logger.py write \
+  --project <project> \
+  --branch <branch> \
+  --type checkpoint \
+  --content "<progress since last entry, decisions made, current state>" \
+  --next "<what you're about to do next>"
+```
 
-- **Progress so far** — what's been built, fixed, or changed since the session started (or since the last checkpoint)
-- **Decisions made** — any choices settled during this segment, with brief reasoning
-- **Current state** — where things stand right now: what's working, what's half-done, any dirty git state worth noting
-- **Next steps** — what you're about to do next (useful context if the session crashes or `/clear` is run)
-
-Keep it concise — this is a snapshot, not a session summary. A few bullet points per section is enough.
-
-If there's already a checkpoint from earlier in the session, leave it in place and add the new one below it. Checkpoints are append-only within a session.
-
----
+Keep it concise — a few bullet points per topic. This is a snapshot, not a session summary.
 
 ### 3 — Confirm
 
-Report back briefly:
-
-> "Checkpoint saved in SESSION.md at HH:MM. Safe to `/clear` or continue."
+> "Checkpoint saved at HH:MM. Safe to `/clear` or continue."
 
 Do **not** propose commits, update the roadmap, or archive anything. That's `/finish`'s job.

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-session
-description: Run the session start routine — ask about available time and hard stops, read SESSION.md session note and ROADMAP.md Now priorities, propose a realistic goal for the session. Use when the user says "/start", "/start-session", "let's start", "start session", "begin session", or at the start of any longer session. Skip for quick focused tasks where the goal is already clear.
+description: Run the session start routine — ask about available time and hard stops, read recent session logs and ROADMAP.md priorities, propose a realistic goal. Use when the user says "/start", "/start-session", "let's start", "start session", "begin session", or at the start of any longer session. Skip for quick focused tasks where the goal is already clear.
 ---
 
 # Start Session
@@ -11,30 +11,29 @@ Runs the session start routine documented in CLAUDE.md. Ensures every session be
 
 ## Steps
 
-### 0 — Get the current time and check for stale sessions
+### 0 — Get the current time and check for incomplete sessions
 
 Run `date` to get the actual current time before doing anything else. Use this to:
 - Confirm the correct date for session note labelling
 - Accurately compute cron expressions for hard stop warnings and break reminders
 - Check whether the session start is already past 7PM
 
-Then check whether the previous session ended cleanly by comparing `SESSION.md` mtime against the most recent JSONL transcript:
+Determine the project name and branch:
 
 ```bash
-PROJECT_DIR="$HOME/.claude/projects/$(pwd | sed 's|/|-|g')"
-LATEST_JSONL=$(ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1)
-if [ -n "$LATEST_JSONL" ] && [ -f "SESSION.md" ]; then
-  JSONL_MTIME=$(stat -f "%m" "$LATEST_JSONL")
-  SESSION_MTIME=$(stat -f "%m" "SESSION.md")
-  if [ "$JSONL_MTIME" -gt "$SESSION_MTIME" ]; then
-    echo "⚠️  SESSION.md is older than the last session transcript — previous session may not have run /finish"
-  fi
-fi
+basename "$(git rev-parse --show-toplevel)"
+git rev-parse --abbrev-ref HEAD
 ```
 
-If the check fires, tell the user:
+Then check whether the previous session ended cleanly:
 
-> "It looks like the last session didn't run `/finish` — SESSION.md is older than the most recent transcript. Want me to run `/recover` to reconstruct what happened, or skip and continue from the current SESSION.md?"
+```bash
+session_logger.py tail --project <project> --branch <branch> --limit 1
+```
+
+If the last entry is **not** a `finish` type (i.e. it's a `start`, `checkpoint`, or `break`), the previous session likely crashed or the user forgot `/finish`. Tell the user:
+
+> "The last session entry is a [type], not a finish — the previous session may not have run `/finish`. Want me to run `/recover` to reconstruct what happened, or skip and continue?"
 
 Wait for their answer. If they say recover, invoke `/recover` before continuing with step 1.
 
@@ -42,7 +41,7 @@ Wait for their answer. If they say recover, invoke `/recover` before continuing 
 
 ### 1 — Ask the two questions
 
-Before reading anything, ask:
+Before reading anything else, ask:
 
 > "How much time do we have today, and any hard stops during the session?"
 
@@ -51,55 +50,51 @@ Wait for the answer. Use it to calibrate everything that follows — a 30-minute
 **If the user mentions a hard stop at a specific time** (e.g. "lunch at 1pm", "run at 2:30"), schedule a one-shot warning 15 minutes before using CronCreate:
 
 - `cron`: derived from the stop time minus 15 minutes (e.g. stop at 13:00 → `45 12 * * *`)
-- `prompt`: `⚠️ Hard stop in ~15 mins — time to reach a clean stopping point and run /finish.`
+- `prompt`: `Hard stop in ~15 mins — time to reach a clean stopping point and run /finish.`
 - `recurring`: `false`
 
 Report the job ID so it can be cancelled if plans change.
 
 ---
 
-### 2 — Archive session notes (direct-to-main only)
+### 2 — Restore context from session logs
 
-`docs/session_log.md` is append-only — entries are added at the bottom when a PR merges. Feature branches handle their own archiving at merge time.
+Read the last few entries to understand where things left off:
 
-**Only do this step if the previous session was on `main` directly** (i.e. no PR involved):
+```bash
+session_logger.py tail --project <project> --branch <branch> --limit 5
+```
 
-1. Read `SESSION.md` and locate the most recent session note block.
-2. Check whether `docs/session_log.md` already has an entry for that date + branch — if so, skip.
-3. Append the session note to the bottom of `docs/session_log.md` with the heading `## YYYY-MM-DD HH:MM | main`.
-4. In `SESSION.md`, delete all but the most recent session note to keep the file lean.
+If no entries exist for this branch, check if there's context from the project's main branch:
 
-Skip entirely if the previous session was on a feature branch — that branch's notes will be appended when the PR merges.
+```bash
+session_logger.py tail --project <project> --branch main --limit 3
+```
+
+Surface the most recent finish entry's `**Next:**` field — that's the handover from last session. Present it verbatim (or a tight summary) before proposing a goal, so the user knows you've picked up exactly where things left off.
 
 ---
 
-### 3 — Read the current state
-
-Read these files:
+### 3 — Read the roadmap
 
 ```
-SESSION.md     — latest session note + Decisions for next session
 ROADMAP.md     — Now / Next / Later priorities
 ```
 
 Extract:
-- The **Handover prompt** from the latest session note in `SESSION.md` — read this first. It's a self-contained paragraph written by the previous session specifically for you. Surface it verbatim (or a tight summary) before proposing a goal, so the user knows you've picked up exactly where things left off.
-- The **Now** priorities from `ROADMAP.md`
-- The **Next** items and which is first in line
-- The **Decisions for next session** from the latest session note in `SESSION.md`
+- The **Now** priorities
+- The first **Next** item in line
 - Any open items from the previous session that weren't completed
-
-Run `gh pr list --state open --json number,headRefName,labels,createdAt,isDraft | jq -r '.[] | "\(.number) | \(.headRefName) | \(.labels | map(.name) | join(", ")) | \(if .isDraft then "draft" else "open" end) | \(.createdAt[:10])"' | sort -t'|' -k1 -n` and display the results as a table (PR | Branch | Label | Status | Created). This gives a quick overview of in-flight work before proposing the session goal.
 
 ---
 
 ### 4 — Check open PRs
 
 ```bash
-gh pr list --state open
+gh pr list --state open --json number,headRefName,labels,createdAt,isDraft | jq -r '.[] | "\(.number) | \(.headRefName) | \(.labels | map(.name) | join(", ")) | \(if .isDraft then "draft" else "open" end) | \(.createdAt[:10])"' | sort -t'|' -k1 -n
 ```
 
-For each open PR, check if it has a `## TODO before merge` checklist in the description. If so, surface the outstanding items to the user — these are likely the first things to pick up this session.
+Display as a table (PR | Branch | Label | Status | Created). For each open PR, check if it has a `## TODO before merge` checklist in the description. If so, surface the outstanding items — these are likely the first things to pick up this session.
 
 ---
 
@@ -125,7 +120,7 @@ Rules:
 **If the session is 30 minutes or shorter:** schedule a one-shot end warning instead of a recurring check-in — fire ~5 minutes before the end of the stated session duration:
 
 - `cron`: current time + (duration - 5 minutes), pinned to today's date
-- `prompt`: `⚠️ Session almost up — time to reach a clean stopping point and run /finish.`
+- `prompt`: `Session almost up — time to reach a clean stopping point and run /finish.`
 - `recurring`: `false`
 
 **If the session is longer than 30 minutes:** schedule a recurring 30-minute check-in:
@@ -139,6 +134,18 @@ Confirm to the user that the timer is set, and note the job ID so it can be canc
 If the session is running past **7PM**, say so directly:
 
 > "It's past 7PM — want to wrap up and pick this up next session?"
+
+---
+
+### 7 — Write the start entry
+
+```bash
+session_logger.py write \
+  --project <project> \
+  --branch <branch> \
+  --type start \
+  --content "<session goal, available time, approach>"
+```
 
 ---
 

--- a/zsh/01_env.zsh
+++ b/zsh/01_env.zsh
@@ -29,3 +29,4 @@ export SDKMAN_DIR="$HOME/.sdkman"
 [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
 
 
+export SESSION_LOGS_DATA=~/Tech/Projects/personal/session-logs


### PR DESCRIPTION
## Summary

Replaces the in-repo SESSION.md convention with a `session_logger.py` CLI that stores session notes in a private data repo (`$SESSION_LOGS_DATA`). This eliminates the merge-time cleanup ceremony — no more prefixed commits, manual resets, or archiving session notes before merging PRs.

## Key changes

- **CLAUDE.md** — new "Session logging" section replacing SESSION.md conventions; updated `/clear` guidance
- **All 6 session skills** (start, finish, save, break, recover) — rewritten to call `session_logger.py write/tail` instead of reading/writing SESSION.md
- **zsh/01_env.zsh** — exports `SESSION_LOGS_DATA` pointing to the data repo

## Gotchas

- `session_logger.py` must be on PATH (installed in `~/bin/` via setup.sh from the session-logs repo)
- The data repo at `$SESSION_LOGS_DATA` must exist and be initialised separately — this PR only adds the env var

## Test plan

- [x] `/start` reads recent entries from session log
- [x] `/save` writes checkpoint entries
- [x] `/break` writes break entries and cancels timer
- [x] `/finish` writes finish entries with auto-push
- [x] `/recover` detects incomplete sessions from log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)