### PR TITLE
Session skills: jotter ls pre-check + /start fast-path

### DIFF
--- a/.claude/skills/save-session/SKILL.md
+++ b/.claude/skills/save-session/SKILL.md
@@ -31,6 +31,14 @@ git rev-parse --abbrev-ref HEAD
 
 ### 1 — Read recent context
 
+First check whether a log exists for this project/branch — cheaper than letting `tail` error:
+
+```bash
+jotter ls --project <project>
+```
+
+If the branch isn't listed, skip the read (nothing to duplicate) and go straight to step 2. Otherwise:
+
 ```bash
 jotter tail --project <project> --branch <branch> --limit 3
 ```

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -43,9 +43,11 @@ Wait for their answer. If they say recover, invoke `/recover` before continuing 
 
 Before reading anything else, ask:
 
-> "How much time do we have today, and any hard stops during the session?"
+> "How much time do we have today, and any hard stops during the session? Or already have a goal in mind?"
 
 Wait for the answer. Use it to calibrate everything that follows — a 30-minute session gets one small task, a 2-hour session can tackle the next sprint item.
+
+If the user already has a goal in mind, skip the time-budget calibration and cron pacing — go straight to step 2 for context restoration, then work toward their stated goal.
 
 **If the user mentions a hard stop at a specific time** (e.g. "lunch at 1pm", "run at 2:30"), schedule a one-shot warning 15 minutes before using CronCreate:
 

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -59,17 +59,25 @@ Report the job ID so it can be cancelled if plans change.
 
 ### 2 — Restore context from session logs
 
-Read the last few entries to understand where things left off:
+First check which branches have logs — cheaper than letting `tail` error when nothing exists:
+
+```bash
+jotter ls --project <project>
+```
+
+If the current branch has a log, read its last few entries:
 
 ```bash
 jotter tail --project <project> --branch <branch> --limit 5
 ```
 
-If no entries exist for this branch, check if there's context from the project's main branch:
+If the current branch isn't in `jotter ls` but `main` is, fall back to that for broader project context:
 
 ```bash
 jotter tail --project <project> --branch main --limit 3
 ```
+
+If neither exists, skip straight to step 3 — no prior context to restore.
 
 Surface the most recent finish entry's `**Next:**` field — that's the handover from last session. Present it verbatim (or a tight summary) before proposing a goal, so the user knows you've picked up exactly where things left off.
 


### PR DESCRIPTION
## Summary

Two small improvements to the session-management skills, shaken loose
by a session that surfaced them both:

1. **Pre-check jotter log presence before tail.** `jotter tail` errors
   when no log exists yet for the project/branch combination — normal
   on first-use branches, but adds noise to otherwise clean `/start`
   and `/save` runs. The skills now gate the `tail` on a cheap
   `jotter ls` check, making a missing log a branch of control flow
   rather than an error to recover from.
2. **Offer a fast-path on `/start` for sessions with a goal already
   in mind.** The opening "how much time, any hard stops" question is
   the right default, but gets in the way when the user already knows
   what they want to do. The question now reads "…or already have a
   goal in mind?" — when the user answers with a concrete goal, the
   skill skips time-budget calibration and cron pacing and goes
   straight to context restoration + the stated goal.

## Key changes

- `.claude/skills/save-session/SKILL.md` — `jotter ls` pre-check
  before step 1's `tail`
- `.claude/skills/start-session/SKILL.md` — `jotter ls` pre-check
  before step 2's `tail` (with a skip-to-step-3 fallback when no
  branches are logged), plus the reframed opener with a fast-path
  branch

## Gotchas / things to be aware of

- The fast-path relies on the model reading the user's intent rather
  than matching a literal keyword. Less explicit than "say 'skip'",
  but the standard clarifying-question fallback covers ambiguous
  cases.
- Adds one extra `jotter` invocation per session-start / checkpoint
  (negligible — it's a directory read).

## References

- The overwrite that exposed both of these was caused by a bug in
  `jotter setup` — sister PR in the jotter repo fixes that:
  https://github.com/sebjacobs/jotter/pull/17

## Test plan

- [ ] Run `/start` on a branch with no jotter log — confirm `jotter ls`
      is consulted and the skill skips straight to step 3 when neither
      branch nor main have logs
- [ ] Run `/start` saying "let's finish the auth refactor" — confirm
      the skill skips time-budget calibration and goes to context
      restoration
- [ ] Run `/start` with no stated goal — confirm the structured path
      (time budget, hard stops, cron pacing) still runs
- [ ] Run `/save` on a fresh branch — confirm `jotter ls` pre-check
      avoids the `tail` error

