### PR TITLE
Session skill + permission quality-of-life tweaks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,8 @@
       "Read",
       "WebFetch",
       "WebSearch",
-      "Write"
+      "Write",
+      "Bash(jotter:*)"
     ],
     "deny": [
       "Bash(rm -rf *)",

--- a/.claude/skills/save-session/SKILL.md
+++ b/.claude/skills/save-session/SKILL.md
@@ -31,6 +31,14 @@ git rev-parse --abbrev-ref HEAD
 
 ### 1 — Read recent context
 
+First check whether a log exists for this project/branch — cheaper than letting `tail` error:
+
+```bash
+jotter ls --project <project>
+```
+
+If the branch isn't listed, skip the read (nothing to duplicate) and go straight to step 2. Otherwise:
+
 ```bash
 jotter tail --project <project> --branch <branch> --limit 3
 ```

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -43,9 +43,11 @@ Wait for their answer. If they say recover, invoke `/recover` before continuing 
 
 Before reading anything else, ask:
 
-> "How much time do we have today, and any hard stops during the session?"
+> "How much time do we have, and any hard stops? Already have a goal in mind? Or skip?"
 
 Wait for the answer. Use it to calibrate everything that follows — a 30-minute session gets one small task, a 2-hour session can tackle the next sprint item.
+
+If the user already has a goal in mind, skip the time-budget calibration and cron pacing — go straight to step 2 for context restoration, then work toward their stated goal.
 
 **If the user mentions a hard stop at a specific time** (e.g. "lunch at 1pm", "run at 2:30"), schedule a one-shot warning 15 minutes before using CronCreate:
 

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -59,17 +59,25 @@ Report the job ID so it can be cancelled if plans change.
 
 ### 2 — Restore context from session logs
 
-Read the last few entries to understand where things left off:
+First check which branches have logs — cheaper than letting `tail` error when nothing exists:
+
+```bash
+jotter ls --project <project>
+```
+
+If the current branch has a log, read its last few entries:
 
 ```bash
 jotter tail --project <project> --branch <branch> --limit 5
 ```
 
-If no entries exist for this branch, check if there's context from the project's main branch:
+If the current branch isn't in `jotter ls` but `main` is, fall back to that for broader project context:
 
 ```bash
 jotter tail --project <project> --branch main --limit 3
 ```
+
+If neither exists, skip straight to step 3 — no prior context to restore.
 
 Surface the most recent finish entry's `**Next:**` field — that's the handover from last session. Present it verbatim (or a tight summary) before proposing a goal, so the user knows you've picked up exactly where things left off.
 


### PR DESCRIPTION
## Summary

Three small, independent improvements to session-start flow and permission handling — each reduces friction in day-to-day session kickoff without changing the underlying routine.

## Key changes

- **`jotter ls` pre-check in `/start` and `/save`** — `jotter tail` errors on first-use branches with no log yet; gating the call on a cheap `ls` turns a missing log into a normal control-flow branch rather than an error to recover from.
- **Fast-path on `/start`** — the opening question now offers "…or already have a goal in mind?" so users with a concrete task can skip the time-budget calibration + cron pacing entirely. Structured path still wins when the user defers.
- **`Bash(jotter:*)` tool-prefix allow-rule** — session skills call `jotter` constantly; the prefix form matches every subcommand up front, so session logging stops prompting for confirmation each time.

## Gotchas

- The `jotter:*` prefix entry sits alongside the existing `jotter *` arg-glob entry — belt-and-braces across both match styles until the prefix form is proven sufficient. Safe to drop the arg-glob later.
- The `/start` fast-path relies on the model reading user intent rather than a literal keyword — slightly less explicit than a hard-coded skip, but a clarifying question is the standard fallback.

## Test plan

- [ ] Start a session on a fresh branch with no jotter log — `/start` should skip the `tail` step cleanly, no error
- [ ] Start a session and reply with a concrete goal — should skip time-budget calibration and cron pacing
- [ ] Run any session skill that calls `jotter` — no permission prompt should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)