### PR TITLE
Adopt jotter project / jotter branch in session skills

### DIFF
--- a/.claude/skills/break-session/SKILL.md
+++ b/.claude/skills/break-session/SKILL.md
@@ -18,8 +18,8 @@ Run `date` to get the current time.
 Determine the project name and branch:
 
 ```bash
-basename "$(git rev-parse --show-toplevel)"
-git rev-parse --abbrev-ref HEAD
+PROJECT=$(jotter project)
+BRANCH=$(jotter branch)
 ```
 
 ### 1 — Write the break entry
@@ -28,8 +28,8 @@ Summarise current progress in a few bullet points, then write it:
 
 ```bash
 jotter write \
-  --project <project> \
-  --branch <branch> \
+  --project "$PROJECT" \
+  --branch "$BRANCH" \
   --type break \
   --content "<what's been done, current state, anything half-finished>" \
   --next "<what to pick up on return>"

--- a/.claude/skills/finish-session/SKILL.md
+++ b/.claude/skills/finish-session/SKILL.md
@@ -20,8 +20,8 @@ Run `date` to get the actual current time. Check whether the session is running 
 Determine the project name and branch:
 
 ```bash
-basename "$(git rev-parse --show-toplevel)"
-git rev-parse --abbrev-ref HEAD
+PROJECT=$(jotter project)
+BRANCH=$(jotter branch)
 ```
 
 ---
@@ -32,8 +32,8 @@ Summarise the session — what was built or fixed, key decisions, anything disco
 
 ```bash
 jotter write \
-  --project <project> \
-  --branch <branch> \
+  --project "$PROJECT" \
+  --branch "$BRANCH" \
   --type finish \
   --content "<session summary: what shipped, decisions made, gotchas/debt>" \
   --next "<top priorities for next session, in order>"

--- a/.claude/skills/recover-session/SKILL.md
+++ b/.claude/skills/recover-session/SKILL.md
@@ -16,14 +16,14 @@ Retrospective summary from Claude Code's JSONL session transcript. Use after a c
 Determine the project name and branch:
 
 ```bash
-basename "$(git rev-parse --show-toplevel)"
-git rev-parse --abbrev-ref HEAD
+PROJECT=$(jotter project)
+BRANCH=$(jotter branch)
 ```
 
 Check the last session log entry:
 
 ```bash
-jotter tail --project <project> --branch <branch> --limit 1
+jotter tail --project "$PROJECT" --branch "$BRANCH" --limit 1
 ```
 
 If the last entry is a `finish`, the session ended cleanly — nothing to recover. Tell the user and stop.
@@ -112,8 +112,8 @@ From the extracted conversation, synthesise a recovery entry:
 
 ```bash
 jotter write \
-  --project <project> \
-  --branch <branch> \
+  --project "$PROJECT" \
+  --branch "$BRANCH" \
   --type finish \
   --content "<what was built/fixed, key decisions, where things stopped>" \
   --next "<priorities inferred from the session trajectory>"

--- a/.claude/skills/save-session/SKILL.md
+++ b/.claude/skills/save-session/SKILL.md
@@ -25,8 +25,8 @@ Run `date` to get the current time.
 Determine the project name and branch:
 
 ```bash
-basename "$(git rev-parse --show-toplevel)"
-git rev-parse --abbrev-ref HEAD
+PROJECT=$(jotter project)
+BRANCH=$(jotter branch)
 ```
 
 ### 1 — Read recent context
@@ -34,13 +34,13 @@ git rev-parse --abbrev-ref HEAD
 First check whether a log exists for this project/branch — cheaper than letting `tail` error:
 
 ```bash
-jotter ls --project <project>
+jotter ls --project "$PROJECT"
 ```
 
 If the branch isn't listed, skip the read (nothing to duplicate) and go straight to step 2. Otherwise:
 
 ```bash
-jotter tail --project <project> --branch <branch> --limit 3
+jotter tail --project "$PROJECT" --branch "$BRANCH" --limit 3
 ```
 
 Review the last few entries to understand what's already been captured — avoid duplicating.
@@ -49,8 +49,8 @@ Review the last few entries to understand what's already been captured — avoid
 
 ```bash
 jotter write \
-  --project <project> \
-  --branch <branch> \
+  --project "$PROJECT" \
+  --branch "$BRANCH" \
   --type checkpoint \
   --content "<progress since last entry, decisions made, current state>" \
   --next "<what you're about to do next>"
@@ -70,8 +70,8 @@ For "jot it down" / "make a note" style requests, skip the tail read and write a
 
 ```bash
 jotter write \
-  --project <project> \
-  --branch <branch> \
+  --project "$PROJECT" \
+  --branch "$BRANCH" \
   --type note \
   --content "<the thing to remember>"
 ```

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -21,14 +21,14 @@ Run `date` to get the actual current time before doing anything else. Use this t
 Determine the project name and branch:
 
 ```bash
-basename "$(git rev-parse --show-toplevel)"
-git rev-parse --abbrev-ref HEAD
+PROJECT=$(jotter project)
+BRANCH=$(jotter branch)
 ```
 
 Then check whether the previous session ended cleanly:
 
 ```bash
-jotter tail --project <project> --branch <branch> --limit 1
+jotter tail --project "$PROJECT" --branch "$BRANCH" --limit 1
 ```
 
 If the last entry is **not** a `finish` type (i.e. it's a `start`, `checkpoint`, or `break`), the previous session likely crashed or the user forgot `/finish`. Tell the user:
@@ -64,19 +64,19 @@ Report the job ID so it can be cancelled if plans change.
 First check which branches have logs — cheaper than letting `tail` error when nothing exists:
 
 ```bash
-jotter ls --project <project>
+jotter ls --project "$PROJECT"
 ```
 
 If the current branch has a log, read its last few entries:
 
 ```bash
-jotter tail --project <project> --branch <branch> --limit 5
+jotter tail --project "$PROJECT" --branch "$BRANCH" --limit 5
 ```
 
 If the current branch isn't in `jotter ls` but `main` is, fall back to that for broader project context:
 
 ```bash
-jotter tail --project <project> --branch main --limit 3
+jotter tail --project "$PROJECT" --branch main --limit 3
 ```
 
 If neither exists, skip straight to step 3 — no prior context to restore.
@@ -151,8 +151,8 @@ If the session is running past **7PM**, say so directly:
 
 ```bash
 jotter write \
-  --project <project> \
-  --branch <branch> \
+  --project "$PROJECT" \
+  --branch "$BRANCH" \
   --type start \
   --content "<session goal, available time, approach>"
 ```


### PR DESCRIPTION
## Summary

jotter v0.5.0 ships two tiny helper subcommands — `jotter project` and `jotter branch` — that own the cwd → (project, branch) detection once. This PR swaps the raw `git rev-parse` boilerplate in each session skill for calls to those helpers, so the skills no longer need to know git's CLI vocabulary to talk to jotter.

## Key changes

- `.claude/skills/{start,save,finish,break,recover}-session/SKILL.md` — replace the two `git rev-parse` lines with `PROJECT=$(jotter project)` / `BRANCH=$(jotter branch)`, then use `"$PROJECT"` / `"$BRANCH"` in every downstream `jotter` call.

## Gotchas

- Depends on jotter v0.5.0+ being on PATH. Older binaries will error with "unknown command 'project'" — clear enough that the fix (upgrade jotter) is obvious.
- No dotfiles-wide behaviour changes; every session skill still does exactly what it did before.

## References

- Sister PR in jotter that ships the helper commands: https://github.com/sebjacobs/jotter/pull/19 (merged, released as v0.5.0)

## Test plan

- [ ] Start a session from inside a git repo — `PROJECT=$(jotter project)` resolves to the repo basename, `BRANCH=$(jotter branch)` resolves to the current branch
- [ ] Run `/save`, `/break`, `/finish` end-to-end — all jotter calls land in the expected log
- [ ] Confirm skills error cleanly when run from outside a git repo (jotter's error message surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)