### PR TITLE
Add `proj .` root shortcut and path echo

### DIFF
--- a/zsh/projects.zsh
+++ b/zsh/projects.zsh
@@ -30,6 +30,11 @@ proj() {
   fi
 
   if [[ -z "$name" ]]; then
+    # Bare `proj` inside a project prints its path.
+    if [[ -n "$_proj_root" ]]; then
+      echo "$_proj_root"
+      return 0
+    fi
     echo "Usage: proj <name>"
     echo ""
     print -l "$PROJ_DIR"/*(/:t) "$PROJ_DIR"/private/*(/:t) | grep -Ev '^(ARCHIVE|private)$' | sort

--- a/zsh/projects.zsh
+++ b/zsh/projects.zsh
@@ -5,6 +5,30 @@ PROJ_DIR="$HOME/Tech/Projects/personal"
 
 proj() {
   local name="$1"
+
+  # Resolve the current project root if cwd is inside $PROJ_DIR.
+  local _proj_root=""
+  if [[ "$PWD/" == "$PROJ_DIR"/*/* ]]; then
+    local rel="${PWD#$PROJ_DIR/}"
+    local first="${rel%%/*}"
+    if [[ "$first" == "private" ]]; then
+      local rest="${rel#private/}"
+      _proj_root="$PROJ_DIR/private/${rest%%/*}"
+    elif [[ "$first" != "ARCHIVE" ]]; then
+      _proj_root="$PROJ_DIR/$first"
+    fi
+  fi
+
+  # `proj .` — cd to current project root.
+  if [[ "$name" == "." ]]; then
+    if [[ -z "$_proj_root" ]]; then
+      echo "proj: not inside a project under $PROJ_DIR" >&2
+      return 1
+    fi
+    cd "$_proj_root"
+    return 0
+  fi
+
   if [[ -z "$name" ]]; then
     echo "Usage: proj <name>"
     echo ""


### PR DESCRIPTION
## Summary

Two small quality-of-life additions to the `proj` shell function. `proj .` now cd's to the current project's root from anywhere inside it, and bare `proj` (with no args) echoes the current project's absolute path when cwd is inside one — so it composes cleanly with command substitution (`cd "$(proj)"`). Outside a project, the existing list behaviour is preserved.

## Key changes

- `zsh/projects.zsh` — resolve `_proj_root` from `$PWD` (handling `private/<name>` and excluding `ARCHIVE`), then branch on `proj .` and bare `proj` before the existing name-matching logic.

## Gotchas

- `proj .` errors (non-zero, stderr) when invoked outside `$PROJ_DIR` rather than falling through to the list.
- `ARCHIVE` and the bare `private/` container are deliberately excluded from root resolution — they shouldn't masquerade as projects.
- Requires a reloaded shell (`source ~/.zshrc` or new tab) to pick up the new function body.

## Test plan

- [ ] `cd ~/Tech/Projects/personal/dotfiles/zsh && proj .` lands in `~/Tech/Projects/personal/dotfiles`
- [ ] `cd /tmp && proj .` prints the "not inside a project" error and returns non-zero
- [ ] `cd ~/Tech/Projects/personal/dotfiles/zsh && proj` prints `/Users/.../personal/dotfiles`
- [ ] `cd ~ && proj` still shows the usage + project list
- [ ] `proj dotfiles` still works (regression check)
- [ ] Works for a `private/<name>` project too

🤖 Generated with [Claude Code](https://claude.com/claude-code)