### PR TITLE
Trim git workflow recipes from CLAUDE.md into git_practices.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -165,17 +165,7 @@ When building any static HTML page, follow `~/.claude/docs/web_standards.md`. Ke
 
 **Branch cleanup before raising a PR and before merging:** review every commit with `git log main...<branch> --oneline`. Cleanup commits (renames, fixups, "oops" corrections) are noise — squash them into the commit they belong with. Every commit should tell one clear story. Do this twice: once before raising the PR, and again before merging in case review feedback triggered more fixup commits.
 
-**Squashing without interactive rebase** (interactive rebase is not available in Claude Code sessions — use this instead):
-
-```bash
-git checkout -b feature/<name>-clean origin/main
-git cherry-pick <sha>                          # individual commits to keep as-is
-git cherry-pick --no-commit <sha1> <sha2>      # group commits to squash into one
-git commit -m "..."
-git push origin feature/<name>-clean:feature/<name> --force
-git checkout feature/<name> && git reset --hard origin/feature/<name>
-git branch -D feature/<name>-clean
-```
+**Squashing without interactive rebase:** interactive rebase isn't available in Claude Code — rebuild the branch with `git cherry-pick --no-commit` instead. See `~/.claude/docs/git_practices.md` for the exact recipe.
 
 **Before you merge — checklist:**
 > Re-read this before running any merge command.
@@ -227,37 +217,11 @@ Include a TODO checklist for any remaining steps not yet done on the branch — 
 
 **Labels:** always add an appropriate label when creating a PR. Check available labels with `gh label list` and pick the best fit (e.g. `spike/idea`, `feature`, `spec`, `documentation`, `bug`).
 
-**Docs and specs layout:**
-Projects follow this layout for documentation unless a project-specific process is already in place (check the project's CLAUDE.md first):
-
-```
-docs/
-  spec.md                  ← project-level: what/why, in/out scope, tech choices (lives on main)
-  specs/
-    feature_name/          ← one directory per feature, on its feature branch
-      00_research.md       ← (optional) background reading, spike findings
-      01_spec.md           ← what/why, behaviour, acceptance criteria, in/out scope
-      02_plan.md           ← how: implementation approach, design decisions
-      03_tasks.md          ← step-by-step tasks, maps to TDD test list
-    done/                  ← completed feature directories move here on merge
-```
-
-- `docs/spec.md` is committed to main before any features begin — it is the project's authoritative what/why
-- Feature subdirectories live on their feature branch and merge to main with the feature code
-- Stage files are numbered so the order of work is self-documenting; `00_research.md` is optional
-- On merge, move the feature directory into `docs/specs/done/` to keep the active list uncluttered
-
 **When to skip a feature branch:**
 Small, self-contained changes (typo fixes, doc tweaks, single-line config changes) can be committed directly to main — not everything needs a branch and PR. This is a judgement call each time; when in doubt, ask.
 
-**Branch hygiene — keeping branches focused:**
-Feature branches sometimes accumulate unrelated changes as a session evolves. Before raising a PR, review what's on the branch with `git log main...<branch> --oneline` and `git diff main...<branch> --stat`. If unrelated changes have crept in, split them out:
+**Branch hygiene:** if unrelated changes crept into a feature branch, split them out before raising a PR — focused branches merge sooner and conflict less. The test: can every commit be described in one sentence starting with the feature name?
 
-1. Create a new branch from main: `git checkout main && git checkout -b feature/housekeeping`
-2. Cherry-pick only the relevant commits: `git cherry-pick <sha> <sha>`
-3. Land the focused branch first, then continue feature work on a clean base
+**Detecting merged branches:** `git branch --merged` misses fast-forward rebased branches — always verify with `git diff main...<branch> --stat`. Empty diff = already on main.
 
-The test for whether a branch is focused: can you describe every commit on it in a single sentence that starts with the feature name? If not, it probably needs splitting.
-
-**Branch cleanup:**
-When checking whether feature branches have been merged, `git branch --merged` only detects merge-commit merges — it misses branches that were fast-forward rebased onto main. Always verify with `git diff main...<branch> --stat` as well: if the diff is empty, the branch's changes are already on main regardless of how they got there.
+See `~/.claude/docs/git_practices.md` for the docs/specs directory layout, the full branch hygiene split-out recipe, and the branch triage runbook.

--- a/.claude/docs/git_practices.md
+++ b/.claude/docs/git_practices.md
@@ -148,3 +148,42 @@ git push origin feature/<name>-clean:feature/<name> --force
 git checkout feature/<name> && git reset --hard origin/feature/<name>
 git branch -D feature/<name>-clean
 ```
+
+---
+
+## Docs and specs layout
+
+Projects follow this layout for documentation unless a project-specific process is already in place (check the project's CLAUDE.md first):
+
+```
+docs/
+  spec.md                  ← project-level: what/why, in/out scope, tech choices (lives on main)
+  specs/
+    feature_name/          ← one directory per feature, on its feature branch
+      00_research.md       ← (optional) background reading, spike findings
+      01_spec.md           ← what/why, behaviour, acceptance criteria, in/out scope
+      02_plan.md           ← how: implementation approach, design decisions
+      03_tasks.md          ← step-by-step tasks, maps to TDD test list
+    done/                  ← completed feature directories move here on merge
+```
+
+- `docs/spec.md` is committed to main before any features begin — it is the project's authoritative what/why
+- Feature subdirectories live on their feature branch and merge to main with the feature code
+- Stage files are numbered so the order of work is self-documenting; `00_research.md` is optional
+- On merge, move the feature directory into `docs/specs/done/` to keep the active list uncluttered
+
+---
+
+## Branch hygiene — keeping branches focused
+
+Feature branches sometimes accumulate unrelated changes as a session evolves. Before raising a PR, review what's on the branch with `git log main...<branch> --oneline` and `git diff main...<branch> --stat`. If unrelated changes have crept in, split them out:
+
+1. Create a new branch from main: `git checkout main && git checkout -b feature/housekeeping`
+2. Cherry-pick only the relevant commits: `git cherry-pick <sha> <sha>`
+3. Land the focused branch first, then continue feature work on a clean base
+
+The test for whether a branch is focused: can you describe every commit on it in a single sentence that starts with the feature name? If not, it probably needs splitting.
+
+## Detecting merged branches
+
+When checking whether feature branches have been merged, `git branch --merged` only detects merge-commit merges — it misses branches that were fast-forward rebased onto main. Always verify with `git diff main...<branch> --stat` as well: if the diff is empty, the branch's changes are already on main regardless of how they got there.

--- a/.claude/docs/git_practices.md
+++ b/.claude/docs/git_practices.md
@@ -149,6 +149,10 @@ git checkout feature/<name> && git reset --hard origin/feature/<name>
 git branch -D feature/<name>-clean
 ```
 
+**Conflict handling during `--no-commit` picks:** if a pick conflicts, do **not** run `git cherry-pick --continue` — that finalises the pick as its own commit, which breaks the squash. Instead: resolve the conflict, `git add` the resolved files, then let the remaining `--no-commit` picks run. Only after all picks in the group have staged their changes do you run `git commit -m "..."` once to produce the single squashed commit.
+
+Pick SHAs in chronological order (oldest → newest). Out-of-order picks produce conflicts that would have been clean otherwise.
+
 ---
 
 ## Docs and specs layout


### PR DESCRIPTION
## Summary

Follow-up to #18. The git workflow section in CLAUDE.md was deliberately left verbatim in the previous extract pass because prior attempts to slim it caused concrete mistakes. This PR takes a more surgical approach: **keep every checklist, the five principles, merge strategy, commit format, and process steps in CLAUDE.md** (all the corrective content that drives behaviour), and only move recipes + layout diagrams that don't need to sit in the always-loaded set. Each moved block leaves a one-line summary + pointer behind.

## Key changes

- `.claude/CLAUDE.md` — squashing-without-interactive-rebase recipe → one-liner + pointer; docs/specs layout, branch hygiene recipe, and merged-branch detection → principle + pointer
- `.claude/docs/git_practices.md` — adds docs/specs layout section, full branch hygiene split-out recipe, merged-branch detection section, and a clarification on conflict handling inside the squashing recipe (the `--no-commit` flow breaks if you run `git cherry-pick --continue`)

## Gotchas

- The conflict-handling clarification was driven by an A/B eval: a Sonnet agent following the old recipe suggested `git cherry-pick --continue` after resolving a conflict, which silently breaks the squash. The recipe now spells out the correct flow (resolve → `git add` → let remaining `--no-commit` picks stage → one final `git commit`).
- Chronological-order rule for pick SHAs is now explicit in the recipe — out-of-order picks produce conflicts that would otherwise be clean.

## References

- Depends on #18 (merged)
- Gated by A/B eval per `.claude/docs/eval_config_changes.md`

## Test plan

- [x] CLAUDE.md pointers resolve to real sections in `git_practices.md`
- [x] `git_practices.md` reads coherently as a standalone reference
- [x] No checklist, merge strategy, or commit format removed from CLAUDE.md (corrective content preserved)
- [x] Squashing recipe includes explicit conflict-handling + chronological-order guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)