### PR TITLE
Tidy .gitignore: sectioned layout + signing credential patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,20 @@
 .env
 .venv
 
+# Signing credentials — never commit
+*.p12
+*.pfx            # same format as .p12, different extension (Windows convention)
+*.cer            # the downloaded Apple cert (public, but no reason to commit)
+*.crt
+*.pem            # often contains private keys
+*.key
+*.p8             # App Store Connect API keys
+*.mobileprovision
+*.provisionprofile
+*.certSigningRequest
+*.keychain
+*.keychain-db
+
 # macOS
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,38 +1,56 @@
+# Claude Code
 .claude/rag
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
 .claude/skills/android-cli/
 .claude/worktrees
+
+# Secrets & env
 .secrets.zsh
-.venv
+.secrets/*
 .env
+.venv
+
+# macOS
 .DS_Store
-config/database.yml
-.bundle
+
+# Editors & IDEs
+.idea
+.vscode
+*.swp
+
+# Node / Yarn
 node_modules
 .next
-.idea
-.gradle
-.vscode
 yarn-error.log
 .yarn
 .yarnrc
 .pnp
 .pnp.js
-vendor/cache
+
+# Python
 __pycache__
 .pytest_cache/
-.byebug_history
-public/sitemaps
-tags
-.foreman
-*.swp
 
-### Maven ###
+# Ruby / Rails
+.bundle
+.byebug_history
+.foreman
+config/database.yml
+public/sitemaps
+vendor/cache
+
+# Java / Gradle / Maven
+.gradle
 target/
 
+# ctags
+tags
+
+# Scratch output dirs
 nanobanana-output/
 
+# Project-local scratch (keep the dir, ignore contents)
 tmp/*
 !tmp/.gitkeep
 log/*


### PR DESCRIPTION
## Summary

Reorganises `.gitignore` into labelled sections and adds a block of signing-credential patterns. The file had grown to a flat ~30-entry list with related patterns scattered; this PR makes it scannable and adds defense-in-depth against accidentally committing private keys.

## Key changes

- `.gitignore` grouped into labelled sections (Claude Code, Secrets & env, macOS, Editors, Node, Python, Ruby, Java, ctags, scratch dirs, project-local scratch)
- Added `.secrets/*` alongside `.secrets.zsh` for a directory-based secrets store
- Added a signing-credentials block: `*.p12`, `*.pfx`, `*.cer`, `*.crt`, `*.pem`, `*.key`, `*.p8`, `*.mobileprovision`, `*.provisionprofile`, `*.certSigningRequest`, `*.keychain`, `*.keychain-db`

## Gotchas

- Broad patterns (`*.pem`, `*.key`) may ignore legitimate non-secret files with those extensions. No such files exist in this repo today; force-add with `git add -f` if one appears.
- First commit is pure reorganisation — larger diff than semantic content. Reviewing commit-by-commit is easier than the combined diff.

## References

- Commit hygiene follows `~/.claude/docs/git_practices.md`

## Test plan

- [x] `git check-ignore` on a sample `.p12` path returns a match
- [x] Existing ignored paths (`.claude/settings.local.json`, `node_modules`, `tmp/*`) still match
- [x] `tmp/.gitkeep` and `log/.gitkeep` remain tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)