### PR TITLE
Customise Starship prompt: allow-list modules, show worktree parent, show exit codes

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,4 +1,5 @@
 format = """\
+${custom.worktree_parent}\
 $directory\
 $git_branch\
 $git_commit\
@@ -14,3 +15,15 @@ $character"""
 # globally. Restrict detection to project files.
 [ruby]
 detect_variables = []
+
+# Inside a worktree, $directory shows the worktree's checkout dir as the
+# repo root and loses the parent repo name. Prepend the parent repo
+# basename only when we're actually in a worktree (git-dir and
+# git-common-dir diverge). --path-format=absolute is required so dirname
+# resolves correctly from any cwd.
+[custom.worktree_parent]
+description = "Parent repo basename when inside a git worktree"
+command = "basename $(dirname $(git rev-parse --path-format=absolute --git-common-dir))"
+when = '''[ "$(git rev-parse --git-dir 2>/dev/null)" != "$(git rev-parse --git-common-dir 2>/dev/null)" ]'''
+format = "[$output]($style) › "
+style = "bold cyan"

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -9,7 +9,11 @@ $python\
 $ruby\
 $golang\
 $line_break\
+$status\
 $character"""
+
+[status]
+disabled = false
 
 # Chruby exports RUBY_VERSION into every shell, so detect_variables fires
 # globally. Restrict detection to project files.

--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,0 +1,16 @@
+format = """\
+$directory\
+$git_branch\
+$git_commit\
+$git_state\
+$git_status\
+$python\
+$ruby\
+$golang\
+$line_break\
+$character"""
+
+# Chruby exports RUBY_VERSION into every shell, so detect_variables fires
+# globally. Restrict detection to project files.
+[ruby]
+detect_variables = []

--- a/setup.sh
+++ b/setup.sh
@@ -58,6 +58,7 @@ files=(
   ".claude/skills"
   ".claude/agents"
   ".claude/docs"
+  ".config/starship.toml"
   ".config/opencode/opencode.json"
   ".config/opencode/package.json"
   ".config/opencode/package-lock.json"


### PR DESCRIPTION
## Summary

Starship has been running on defaults since install. Three issues kept compounding: language modules firing in unrelated cwd's (Ruby version on every prompt because Chruby exports `RUBY_VERSION` globally), worktrees indistinguishable from each other in the prompt (the worktree's checkout dir gets treated as the repo root, so the parent project name disappears), and no visibility into the last exit code beyond a colour change on the prompt char.

This PR adds a `~/.config/starship.toml` (symlinked via `setup.sh`) and addresses each in a separate, atomic commit so any one can be reverted independently.

## Key changes

1. **`b8d8bd6` — Add Starship config with explicit module allow-list.** Switches from Starship's opt-out default (everything fires unless disabled) to an opt-in allow-list via `format` override. Only `directory`, the `git_*` modules, `python`, `ruby`, `golang`, `line_break`, and `character` render. Anything else (aws, package, node, java, kubernetes, battery…) is silent until explicitly added. Ruby additionally overrides `detect_variables = []` so Chruby's `RUBY_VERSION` export doesn't trip the module outside Ruby projects.
2. **`c170f1f` — Show parent repo name in prompt when inside a git worktree.** Custom module that prepends the parent repo basename (e.g. `dotfiles › starship-ruby-fix`) only when `git rev-parse --git-dir` and `--git-common-dir` diverge — the canonical worktree test. Uses `--path-format=absolute` so `dirname` resolves correctly from any cwd. Same pattern as jotter (see jotter `CHANGELOG.md` v0.5.x for why `--show-toplevel` is wrong here).
3. **`9dd09aa` — Show non-zero exit codes in prompt.** Enables the `status` module so failures render as red `❌ N` before the prompt char. Silent on success — no noise cost in the happy path. The character module's colour change tells you _that_ something failed; this tells you _with what_.

## Gotchas

- **`detect_variables` is not a valid key on `[python]`.** Earlier iterations of this branch had a `[python] detect_variables = []` override by analogy with Ruby's. Starship logs a warning for unknown keys. Python's module only detects on project files by default (no env-var detection), so no override is needed — already correct as-is.
- **`setup.sh` doesn't overwrite existing symlinks.** Re-running `setup.sh` after this merges won't fix a pre-existing `~/.config/starship.toml` symlink pointing at an old/stale path. If you've been testing this branch via a worktree, you'll need to `rm ~/.config/starship.toml && ./setup.sh` (or `ln -snf ~/dotfiles/.config/starship.toml ~/.config/starship.toml`) post-merge to repoint at the canonical repo.
- **Per-prompt git invocations.** The worktree_parent module runs two `git rev-parse` calls on every render. Starship is already invoking git for the branch/status modules, so the marginal cost is small but non-zero. Considered shelling out to `jotter project` (single source of truth) but rejected — would add a runtime dependency on `jotter` being on PATH for the prompt to render.

## References

- Starship `[ruby]` module docs: https://starship.rs/config/#ruby
- Starship custom modules: https://starship.rs/advanced-config/#custom-commands-in-custom-commands
- jotter `CHANGELOG.md` v0.5.x — `--show-toplevel` vs `--git-common-dir` rationale (mirrors this PR's worktree_parent detection)

## TODO before merge

- [x] Three commits, each atomic and independently revertable
- [x] Branch rebased on latest main (no rebase needed — main hadn't moved)
- [x] `starship explain` runs without warnings
- [x] Verified status module renders correctly with `starship prompt --status=0` and `--status=1`
- [ ] Post-merge: re-point `~/.config/starship.toml` symlink at the canonical repo path

## Test plan

- [ ] Open a fresh shell in `~/dotfiles` (regular checkout, not worktree): expect `dotfiles on  main ❯` — no Ruby version, no AWS, no package version
- [ ] Open a fresh shell in a worktree under `~/dotfiles/.claude/worktrees/<name>`: expect `dotfiles › <name> on  <branch> ❯` — parent repo name appears
- [ ] In a Ruby project (with `Gemfile`): expect Ruby version segment to appear via `via 💎 vX.Y.Z`
- [ ] In a Python project (with `pyproject.toml`): expect Python version + active virtualenv if any
- [ ] Run a failing command (`false`): expect `❌ 1` (red) before the next prompt char, character also turns red
- [ ] Run a successful command after: expect status segment to vanish, character back to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)