### PR TITLE
feat: Let proj mv move a project across categories

### DIFF
--- a/lib/proj.rb
+++ b/lib/proj.rb
@@ -439,25 +439,36 @@ module Proj
       0
     end
 
-    # Rename a project's directory to <new-name> within the same parent, then
-    # carry the per-checkout history that keys off its path: Claude transcripts
-    # (project root + every worktree, migrated precisely) and jotter logs (whose
-    # project name is the dir basename — delegated to `jotter mv`). Confirms
-    # first; the history moves run only after the directory move succeeds.
-    # `mv` shadows any project literally named "mv" — an accepted edge.
+    # Move a project, then carry the per-checkout state that keys off its path:
+    # Claude transcripts (project root + every worktree, migrated precisely),
+    # worktree git registrations, and jotter logs. Two shapes:
+    #
+    #   proj mv <project> <new-name>              rename within the same parent
+    #   proj mv <project> [<new-name>] --to <cat> move into another category
+    #
+    # Without --to it stays a same-parent rename. With --to the project relocates
+    # into another tree (its category), keeping its name unless a <new-name> is
+    # given. Confirms first; the state moves run only after the directory move
+    # succeeds. `mv` shadows any project literally named "mv" — an accepted edge.
     def cmd_mv(map, args)
-      old, new = args
-      return error("Usage: proj mv <project> <new-name>") if [old, new].any? { |a| a.nil? || a.empty? }
-      return error("proj mv: <new-name> must be a single path segment (no '/')") if new.include?("/")
+      positionals, to = parse_mv_args(args)
+      old = positionals[0]
+      explicit_new = positionals[1]
+      return error(MV_USAGE) if old.nil? || old.empty?
 
       old_path = resolve_project(old, map)
       return 1 if old_path.nil?
 
-      new_path = File.join(File.dirname(old_path), new)
-      return error("proj mv: '#{new}' already exists at #{new_path}") if File.exist?(new_path)
+      dest_parent, new_name = mv_destination(old_path, explicit_new, to)
+      return 1 if dest_parent.nil?
+      return error("proj mv: <new-name> must be a single path segment (no '/')") if new_name.include?("/")
+
+      new_path = File.join(dest_parent, new_name)
+      return error("proj mv: destination '#{dest_parent}' is not a directory") unless File.directory?(dest_parent)
+      return error("proj mv: '#{new_name}' already exists at #{new_path}") if File.exist?(new_path)
 
       old_name = File.basename(old_path)
-      return 1 unless @confirm.call("Move project '#{old_name}' -> '#{new}' (directory, Claude history, jotter logs)? [y/N] ")
+      return 1 unless @confirm.call("Move project '#{old_name}' -> '#{new_path}' (directory, Claude history, jotter logs)? [y/N] ")
 
       begin
         @sys.move(old_path, new_path)
@@ -467,9 +478,83 @@ module Proj
 
       migrate_claude_history(old_path, new_path)
       repair_worktrees(new_path)
-      migrate_jotter_logs(old_name, new, new_path)
+      migrate_jotter_logs(old_name, new_name, old_path, new_path)
       change_dir(new_path + @pwd[old_path.length..]) if @pwd == old_path || @pwd.start_with?("#{old_path}/")
       0
+    end
+
+    MV_USAGE = "Usage: proj mv <project> <new-name> | proj mv <project> [<new-name>] --to <category>"
+
+    # Split the mv argv into positionals and the optional --to value. `--to` (or
+    # `--to=cat`) names a destination category; a bare `--to` with no value comes
+    # back as "" so the caller can flag it. Returns [positionals, to] where to is
+    # nil when the flag is absent.
+    def parse_mv_args(args)
+      positionals = []
+      to = nil
+      i = 0
+      while i < args.length
+        arg = args[i]
+        if arg == "--to"
+          to = args[i + 1] || ""
+          i += 2
+        elsif arg.start_with?("--to=")
+          to = arg.split("=", 2)[1]
+          i += 1
+        else
+          positionals << arg
+          i += 1
+        end
+      end
+      [positionals, to]
+    end
+
+    # Work out where the project should land. Without --to it's a same-parent
+    # rename, so <new-name> is required. With --to the destination parent is the
+    # named category's directory and the name is kept unless overridden. Returns
+    # [dest_parent, new_name], or [nil, nil] after reporting a usage error.
+    def mv_destination(old_path, explicit_new, to)
+      if to.nil?
+        if explicit_new.nil? || explicit_new.empty?
+          error(MV_USAGE)
+          return [nil, nil]
+        end
+        return [File.dirname(old_path), explicit_new]
+      end
+
+      dest_parent = resolve_destination_parent(to)
+      return [nil, nil] if dest_parent.nil?
+
+      name = explicit_new.nil? || explicit_new.empty? ? File.basename(old_path) : explicit_new
+      [dest_parent, name]
+    end
+
+    # Map a --to category to the directory new projects of that category sit
+    # under. The first segment names the tree (by its type, or its dir's
+    # basename); any further segments are the namespace a deeper tree needs
+    # (a depth-2 `client` tree wants one, e.g. `client/acme`). Reports and
+    # returns nil on an unknown category or the wrong namespace depth.
+    def resolve_destination_parent(category)
+      segs = category.to_s.split("/").reject(&:empty?)
+      if segs.empty?
+        error("proj mv: --to needs a category")
+        return nil
+      end
+
+      tree = @trees.find { |t| t[:type] == segs[0] } || @trees.find { |t| File.basename(t[:dir]) == segs[0] }
+      unless tree
+        error("proj mv: unknown destination category '#{segs[0]}' (known: #{@trees.map { |t| t[:type] }.uniq.join(', ')})")
+        return nil
+      end
+
+      namespace = segs.drop(1)
+      expected = tree[:depth] - 1
+      if namespace.length != expected
+        error("proj mv: '#{tree[:type]}' projects sit #{tree[:depth]} level(s) deep — --to needs #{expected} namespace segment(s)")
+        return nil
+      end
+
+      File.join(tree[:dir], *namespace)
     end
 
     # Moving the whole project tree relocates each linked worktree too, so git's
@@ -500,13 +585,17 @@ module Proj
       Gwt::ClaudeHistory.migrate_paths(sys: @sys, home: @home, pairs: pairs, out: @out, err: @err)
     end
 
-    # Hand the jotter log rename to jotter itself (it owns its git-backed store),
+    # Hand the jotter log move to jotter itself (it owns its git-backed store),
     # but only for a git repo — jotter keys logs by the toplevel basename and has
-    # nothing to migrate for a plain directory.
-    def migrate_jotter_logs(old_name, new_name, new_path)
+    # nothing to migrate for a plain directory. A same-parent rename stays within
+    # one store, so no source dir is passed; a cross-category move can land in a
+    # different store, so the old parent goes along as +from_dir+ for jotter to
+    # resolve the source store from.
+    def migrate_jotter_logs(old_name, new_name, old_path, new_path)
       return unless File.exist?(File.join(new_path, ".git"))
 
-      @jotter.call(old_name, new_name, new_path)
+      from_dir = File.dirname(old_path) == File.dirname(new_path) ? nil : File.dirname(old_path)
+      @jotter.call(old_name, new_name, from_dir, new_path)
     end
 
     # Inside a project, echo its root (handy for `cd "$(proj)"`); outside any
@@ -606,13 +695,18 @@ if __FILE__ == $PROGRAM_NAME
     answer&.downcase == "y"
   end
 
-  # Hand a project-logs rename to jotter, which owns its git-backed store. Run
-  # from inside the moved project so jotter resolves the right data_dir from the
-  # .jotter config that travelled with the directory. Best-effort: a project
-  # with no logs makes jotter exit non-zero, which is condensed to one line
-  # rather than failing the whole move.
-  jotter_sink = lambda do |old_name, new_name, cwd|
-    out, status = Open3.capture2e("jotter", "mv", old_name, new_name, chdir: cwd)
+  # Hand a project-logs move to jotter, which owns its git-backed store. Run from
+  # inside the moved project so jotter resolves the destination data_dir from the
+  # .jotter config that now serves the new location. For a cross-category move
+  # +from_dir+ is the project's old parent, passed as `--from` so jotter resolves
+  # the source store from where the project used to live and relocates the logs
+  # across stores; for a same-parent rename it's nil and jotter renames in place.
+  # Best-effort: a project with no logs makes jotter exit non-zero, which is
+  # condensed to one line rather than failing the whole move.
+  jotter_sink = lambda do |old_name, new_name, from_dir, cwd|
+    args = ["jotter", "mv", old_name, new_name]
+    args += ["--from", from_dir] if from_dir
+    out, status = Open3.capture2e(*args, chdir: cwd)
     $stderr.puts "proj: jotter logs not migrated (#{out.lines.first&.strip})" unless status.success?
   rescue StandardError => e
     $stderr.puts "proj: jotter not available, logs left under '#{old_name}' (#{e.message})"

--- a/test/lib/proj_test.rb
+++ b/test/lib/proj_test.rb
@@ -655,10 +655,19 @@ class ProjMvTest < Minitest::Test
     @root = Dir.mktmpdir
     @home = Dir.mktmpdir
     @personal = File.join(@root, "personal")
+    @client = File.join(@root, "client")
+    @opensource = File.join(@root, "opensource")
     @proj = File.join(@personal, "cadence")
+    @client_proj = File.join(@client, "acme", "widget")
     FileUtils.mkdir_p(@proj)
     FileUtils.mkdir_p(File.join(@personal, "cadence-extra"))
-    @trees = [{ dir: @personal, depth: 1, exclude: [], type: "personal" }]
+    FileUtils.mkdir_p(@client_proj)
+    FileUtils.mkdir_p(@opensource)
+    @trees = [
+      { dir: @personal, depth: 1, exclude: [], type: "personal" },
+      { dir: @client, depth: 2, exclude: [], type: "client" },
+      { dir: @opensource, depth: 1, exclude: [], type: "opensource" },
+    ]
     @projects = File.join(@home, ".claude", "projects")
     FileUtils.mkdir_p(@projects)
     @jotter_calls = []
@@ -685,7 +694,7 @@ class ProjMvTest < Minitest::Test
     Proj::App.new(
       trees: @trees, pwd: @root, out: @out, err: @err,
       cd: ->(p) { @cd << p }, cache: ->(_) {}, paths: ->(_) {}, types: ->(_) {}, tags: ->(_) {},
-      home: @home, confirm: ->(_) { confirm }, jotter: ->(o, n, p) { @jotter_calls << [o, n, p] }, git: git
+      home: @home, confirm: ->(_) { confirm }, jotter: ->(o, n, from, p) { @jotter_calls << [o, n, from, p] }, git: git
     )
   end
 
@@ -752,7 +761,7 @@ class ProjMvTest < Minitest::Test
   def test_mv_delegates_to_jotter_for_a_git_repo
     FileUtils.mkdir_p(File.join(@proj, ".git"))
     app.run(["mv", "cadence", "notes"])
-    assert_equal [["cadence", "notes", File.join(@personal, "notes")]], @jotter_calls
+    assert_equal [["cadence", "notes", nil, File.join(@personal, "notes")]], @jotter_calls
   end
 
   def test_mv_skips_jotter_for_a_non_git_directory
@@ -795,6 +804,66 @@ class ProjMvTest < Minitest::Test
   def test_mv_requires_two_arguments
     assert_equal 1, app.run(["mv", "cadence"])
     assert_match(/Usage: proj mv/, @err.string)
+  end
+
+  def test_mv_to_moves_into_another_category_keeping_the_name
+    assert_equal 0, app.run(["mv", "widget", "--to", "personal"])
+    assert path_exists?(File.join(@personal, "widget"))
+    refute path_exists?(@client_proj)
+  end
+
+  def test_mv_to_renames_while_moving_into_another_category
+    assert_equal 0, app.run(["mv", "cadence", "renamed", "--to", "opensource"])
+    assert path_exists?(File.join(@opensource, "renamed"))
+    refute path_exists?(@proj)
+  end
+
+  def test_mv_to_accepts_an_equals_form
+    assert_equal 0, app.run(["mv", "cadence", "--to=opensource"])
+    assert path_exists?(File.join(@opensource, "cadence"))
+  end
+
+  def test_mv_to_a_namespaced_tree_places_under_the_namespace
+    assert_equal 0, app.run(["mv", "cadence", "--to", "client/acme"])
+    assert path_exists?(File.join(@client, "acme", "cadence"))
+  end
+
+  def test_mv_to_rejects_an_unknown_category
+    assert_equal 1, app.run(["mv", "cadence", "--to", "nope"])
+    assert_match(/unknown destination category 'nope'/, @err.string)
+    assert path_exists?(@proj)
+  end
+
+  def test_mv_to_rejects_the_wrong_namespace_depth
+    assert_equal 1, app.run(["mv", "cadence", "--to", "client"])
+    assert_match(/namespace segment/, @err.string)
+    assert path_exists?(@proj)
+  end
+
+  def test_mv_to_rejects_an_existing_target
+    FileUtils.mkdir_p(File.join(@personal, "widget"))
+    assert_equal 1, app.run(["mv", "widget", "--to", "personal"])
+    assert_match(/already exists/, @err.string)
+  end
+
+  def test_mv_to_migrates_claude_history_across_categories
+    seed_history(@client_proj)
+    app.run(["mv", "widget", "--to", "personal"])
+    assert path_exists?(File.join(@projects, enc(File.join(@personal, "widget")), "s.jsonl"))
+    refute path_exists?(File.join(@projects, enc(@client_proj)))
+  end
+
+  def test_mv_to_passes_the_old_parent_as_from_dir_for_a_git_repo
+    FileUtils.mkdir_p(File.join(@client_proj, ".git"))
+    app.run(["mv", "widget", "--to", "personal"])
+    assert_equal [["widget", "widget", File.join(@client, "acme"), File.join(@personal, "widget")]], @jotter_calls
+  end
+
+  def test_mv_to_cds_into_the_moved_project_when_inside_it
+    inside = app
+    inside.instance_variable_set(:@pwd, File.join(@client_proj, "lib"))
+    inside.run(["mv", "widget", "--to", "personal"])
+    assert_equal [File.join(@personal, "widget", "/lib")], @cd
   end
 
   private


### PR DESCRIPTION
## Motivation

`proj mv <project> <new-name>` only renamed a project within its own parent — it forced the new path to `File.dirname(old_path)` and rejected any `/` in the name. So a project that landed in the wrong tree (e.g. a personal tool that grew inside a client folder) couldn't be relocated with the one command that already knows how to carry a project's per-checkout state: you'd move the directory by hand and then chase down the Claude transcripts, worktree git registrations, and jotter logs yourself.

## Summary

- `proj mv` gains `--to <category>`: the project relocates into another tree, keeping its name unless an explicit new name is given (`proj mv dox-cli --to personal`, `proj mv dox-cli newname --to personal`). The no-`--to` same-parent rename is unchanged.
- The category resolves against the manifest trees — first segment names the tree (by type or dir basename), further segments are the namespace a deeper tree needs (`--to client/acme` for a depth-2 tree); wrong depth is a clear error.
- All four migrations a rename already did follow the cross-category move: directory, Claude history, worktree repair, and jotter logs.
- The jotter step now passes the project's old parent as `jotter mv --from` only when the parent actually changes, so a cross-category move relocates logs across stores. Pairs with the matching `--from` support in jotter ([sebjacobs/jotter#36](https://github.com/sebjacobs/jotter/pull/36)).
- `--to cat` and `--to=cat` both accepted; bare `--to` is a usage error. Confirm prompt now shows the full destination path.

See individual commit message for the details. Full suite green (363 runs, 11 new).

## Questions/Feedback

- Category resolution matches by tree `type` or dir basename — reasonable, or should it be stricter (type only)?